### PR TITLE
fix(syosetu): change oneshot chapter name

### DIFF
--- a/src/sources/jp/syosetu.js
+++ b/src/sources/jp/syosetu.js
@@ -141,7 +141,7 @@ const parseNovelAndChapters = async (novelUrl) => {
 
         // add single chapter
         chapters.push({
-            chapterName: novel.novelName,
+            chapterName: "Oneshot",
             releaseDate: cheerioQuery("head")
                 .find("meta[name='WWWC']")
                 .attr("content"), // get date from metadata


### PR DESCRIPTION
Changed oneshot chapter names to "Oneshot" to avoid too long chapters names destroying UI.