### PR TITLE
fix(download_more): fix invalid prop type error

### DIFF
--- a/src/screens/novel/components/DownloadCustomChapterModal.js
+++ b/src/screens/novel/components/DownloadCustomChapterModal.js
@@ -64,7 +64,7 @@ const DownloadCustomChapterModal = ({
             color={theme.colorAccent}
           />
           <TextInput
-            value={text}
+            value={`${text}`}
             style={{color: theme.textColorPrimary, marginHorizontal: 4}}
             keyboardType="numeric"
             onChangeText={onChangeText}


### PR DESCRIPTION
TextInput::value should be a string, not a number, that's why conversion int>string is needed