### PR TITLE
Fixed Last Read Crash

### DIFF
--- a/src/hooks/reduxHooks.js
+++ b/src/hooks/reduxHooks.js
@@ -80,8 +80,10 @@ const useContinueReading = (chapters, novelId) => {
     );
   }
 
+  // If the last read chapter is 100% done, set the next chapter as the 'last read'.
+  // If all chapters are read, then set the last chapter in the list as the last read (Fixed bug)
   if (!lastReadChapter) {
-    lastReadChapter = chapters.find(obj => obj.read === 0);
+    lastReadChapter = chapters.find(obj => obj.read === 0) || chapters[chapters.length - 1];
   }
 
   return { lastReadChapter, position };


### PR DESCRIPTION
Fixes a bug where the app would crash if all the chapters in a novel were read, and the user tried to open it.

Video of before and after applying the change

https://user-images.githubusercontent.com/13577339/161591854-4d0fe1a7-2293-4d3b-8613-e412a2278c2e.mp4

(If the above video doesn't work) https://youtu.be/MoH2Gd7OAGY