### PR TITLE
fix(typo): spelling mistake causing a crash

### DIFF
--- a/src/screens/reader/ReaderScreen.js
+++ b/src/screens/reader/ReaderScreen.js
@@ -232,7 +232,7 @@ const Chapter = ({ route, navigation }) => {
           y: position.position,
           animated: false,
         });
-        setWebViewStartScroll(position.percentage);
+        setWebViewScroll(position.percentage);
       }
       setFirstLayout(false);
     }


### PR DESCRIPTION
Because of last-minute name changes to the functions I forgot to change the name of `setWebViewStartScroll` to `setWebViewScroll` when it was called in `scrollToSavedProgress` and it was causing the app to crash