### PR TITLE
fix(tts): Android11 Manifest TTS Support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,12 @@
   	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
   	<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
 
+	<queries>
+		<intent>
+			<action android:name="android.intent.action.TTS_SERVICE" />
+		</intent>
+	</queries>
+
   	<application 
 	  	android:name=".MainApplication"
 		android:largeHeap="true"


### PR DESCRIPTION
Add to AndroidManifest.xml a clause about querying TTS to remove `Unresolved Promise: No TTS Engine Installed` error in Android 11 Phones.