### PR TITLE
fix(source): Fix NovelUpdates genres

### DIFF
--- a/src/sources/en/novelupdates.js
+++ b/src/sources/en/novelupdates.js
@@ -110,9 +110,11 @@ const parseNovelAndChapters = async novelUrl => {
   novel.novelCover = loadedCheerio('.seriesimg > img').attr('src');
 
   novel.author = loadedCheerio('#showauthors').text().trim();
-
-  novel.genre = loadedCheerio('#seriesgenre').text().trim().replace(/\s/g, ',');
-
+  novel.genre = loadedCheerio('#seriesgenre')
+    .children('a')
+    .map((i, el) => loadedCheerio(el).text())
+    .toArray()
+    .join(',');
   novel.status = loadedCheerio('#editstatus').text().includes('Ongoing')
     ? 'Ongoing'
     : 'Completed';


### PR DESCRIPTION
Before the genres would be split on every space so genres like "Slice of Life" would become "Slice" "Of" "Life"
This would cause react error on every novel with both
"School Life" and "Slice of Life" genres because it would cause duplicate key for genre "Life"