### PR TITLE
Generate versionCode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -122,6 +122,12 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  */
 def enableHermes = project.ext.react.get("enableHermes", false);
 
+ext {
+    versionMajor = 1
+    versionMinor = 1
+    versionPatch = 13
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
@@ -134,8 +140,9 @@ android {
         applicationId 'com.rajarsheechatterjee.LNReader'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.1.13"
+        // Generated version code. Supports versions up to 128.128.256
+        versionCode ((((versionMajor << 10) | versionMinor) << 11) | versionPatch)
+        versionName "$versionMajor.$versionMinor.$versionPatch"
     }
     splits {
         abi {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -140,7 +140,7 @@ android {
         applicationId 'com.rajarsheechatterjee.LNReader'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        // Generated version code. Supports versions up to 128.128.256
+        // Generated version code. Supports versions up to 1024.1024.2048
         versionCode ((((versionMajor << 10) | versionMinor) << 11) | versionPatch)
         versionName "$versionMajor.$versionMinor.$versionPatch"
     }


### PR DESCRIPTION
Instead of just leaving it at 1, this PR implements an automatically incremented (based on the version number) version code.
This implementation supports pretty high version codes, so that should be no issue.
Since the version code is used to differentiate versions in android programmatically, this should allow things like including the app in F-Droid repositories.