### PR TITLE
fix(delete_chapter): Excessive number of pending callbacks warn

### DIFF
--- a/src/database/queries/ChapterQueries.ts
+++ b/src/database/queries/ChapterQueries.ts
@@ -416,7 +416,6 @@ export const deleteChapter = async (
       },
     );
   });
-  console.log('removed from SQL', sourceId, novelId, chapterId);
 };
 
 const getLastReadChapterQuery = `

--- a/src/database/queries/ChapterQueries.ts
+++ b/src/database/queries/ChapterQueries.ts
@@ -379,7 +379,7 @@ const deleteDownloadedImages = async (
       }
     }
   } catch (error) {
-    showToast(error.message);
+    showToast((error as Error).message);
   }
 };
 
@@ -416,6 +416,7 @@ export const deleteChapter = async (
       },
     );
   });
+  console.log('removed from SQL', sourceId, novelId, chapterId);
 };
 
 const getLastReadChapterQuery = `

--- a/src/redux/novel/novel.actions.js
+++ b/src/redux/novel/novel.actions.js
@@ -452,51 +452,36 @@ export const deleteAllChaptersAction =
           res();
         }
 
-        const pendingCallbackLimit = 10;
-
-        if (downloaded.length > pendingCallbackLimit) {
-          /**
-           * @type {Promise<void>[][]}
-           */
-          const removeBatches = [];
-          for (let i = 0; i < downloaded.length; i++) {
-            if (i % pendingCallbackLimit === 0) {
-              removeBatches.push([]);
-            }
-            removeBatches[removeBatches.length - 1].push(
-              new Promise(resolveRemoval => {
-                (async () => {
-                  const chapter = downloaded[i];
-                  await deleteChapter(
-                    sourceId,
-                    chapter.novelId,
-                    chapter.chapterId,
-                  );
-
-                  dispatch({
-                    type: CHAPTER_DELETED,
-                    payload: chapter.chapterId,
-                  });
-                  resolveRemoval();
-                })();
-              }),
-            );
+        const coccurent = 5;
+        /**
+         * @type {Promise<void>[][]}
+         */
+        const removeBatches = [];
+        for (let i = 0; i < downloaded.length; i++) {
+          if (i % coccurent === 0) {
+            removeBatches.push([]);
           }
-          for (const rb of removeBatches) {
-            await Promise.all(rb);
-            console.log('Removed batch #1');
-          }
-        } else {
-          await Promise.all(
-            chapters.map(async chapter => {
-              await deleteChapter(sourceId, chapter.novelId, chapter.chapterId);
+          removeBatches[removeBatches.length - 1].push(
+            new Promise(resolveRemoval => {
+              (async () => {
+                const chapter = downloaded[i];
+                await deleteChapter(
+                  sourceId,
+                  chapter.novelId,
+                  chapter.chapterId,
+                );
 
-              dispatch({
-                type: CHAPTER_DELETED,
-                payload: chapter.chapterId,
-              });
+                dispatch({
+                  type: CHAPTER_DELETED,
+                  payload: chapter.chapterId,
+                });
+                resolveRemoval();
+              })();
             }),
           );
+        }
+        for (const rb of removeBatches) {
+          await Promise.all(rb);
         }
         res();
       })();

--- a/src/redux/novel/novel.actions.js
+++ b/src/redux/novel/novel.actions.js
@@ -447,7 +447,6 @@ export const deleteAllChaptersAction =
     await new Promise((res, rej) => {
       (async () => {
         const downloaded = chapters.filter(f => !!f.downloaded);
-        console.log('dL', downloaded.length);
         if (downloaded.length === 0) {
           res();
         }


### PR DESCRIPTION
Make deleting chapters do 5 coccurent deletion at a time, thus removing the `Excessive number of pending callbacks` warn.