### PR TITLE
Set default TTS settings and add build script for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "prettier": "prettier --write \"./src/**/*.{js,jsx,ts,tsx}\"",
     "buildRelease": "cd android && ./gradlew clean && ./gradlew assembleRelease",
+    "buildReleaseWin": "cd android && .\\gradlew clean && .\\gradlew assembleRelease",
     "open": "open ./android/app/build/outputs/apk/release/",
     "sources:madara": "node scripts/generateMadaraSource.cjs",
     "source:generator": "node scripts/generateSource.cjs",

--- a/src/hooks/useTextToSpeech.js
+++ b/src/hooks/useTextToSpeech.js
@@ -30,6 +30,8 @@ export const useTextToSpeech = (sentences, markChapterAsRead) => {
 
     setTtsStatus('progress');
     Tts.stop();
+    Tts.setDefaultLanguage('en-US');
+    Tts.setDefaultVoice('en-us-x-tpc-network');
     for (let i = ttsPosition.current; i < sentences.length; i++) {
       Tts.speak(sentences[i], {
         androidParams: {


### PR DESCRIPTION
This PR sets the default TTS language to en-US and the default TTS voice to en-us-x-tpc-network for personal use. The network voice provides better quality than the offline voice. It also adds a new script for building the release on Windows.

Changes made:
- Set default TTS language to en-US
- Set default TTS voice to en-us-x-tpc-network
- Add buildReleaseWin script for Windows users

The changes to the TTS settings were made for personal use, as the network voice provides better quality than the offline voice. The new buildReleaseWin script allows Windows users to easily build the release version of the app.
