### PR TITLE
fix(ReadWN): Implemented better chapter assumption

### DIFF
--- a/src/sources/multisrc/readwn/ReadwnScraper.js
+++ b/src/sources/multisrc/readwn/ReadwnScraper.js
@@ -88,7 +88,7 @@ class ReadwnScraper {
 
     let novelChapters = [];
 
-    const novelId = novelUrl.replace('.html', '');
+    const novelId = novelUrl.replace('.html', '').replace(baseUrl, '');
 
     const latestChapterNo = loadedCheerio('.header-stats')
       .find('span > strong')
@@ -96,7 +96,30 @@ class ReadwnScraper {
       .text()
       .trim();
 
-    for (let i = 1; i <= latestChapterNo; i++) {
+    let lastChapterNo = 1;
+    loadedCheerio('.chapter-list li').each(function () {
+      const chapterName = loadedCheerio(this)
+        .find('a .chapter-title')
+        .text()
+        .trim();
+
+      const chapterUrl = loadedCheerio(this).find('a').attr('href').trim();
+
+      const releaseDate = loadedCheerio(this)
+        .find('a .chapter-update')
+        .text()
+        .trim();
+
+      lastChapterNo = loadedCheerio(this).find('a .chapter-no').text().trim();
+
+      const chapter = { chapterName, releaseDate, chapterUrl };
+
+      novelChapters.push(chapter);
+    });
+
+    // Itterate once more before loop to finish off
+    lastChapterNo++;
+    for (let i = lastChapterNo; i <= latestChapterNo; i++) {
       const chapterName = `Chapter ${i}`;
       const chapterUrl = `${novelId}_${i}.html`;
       const releaseDate = null;
@@ -112,7 +135,8 @@ class ReadwnScraper {
   }
 
   async parseChapter(novelUrl, chapterUrl) {
-    const url = chapterUrl;
+    const baseUrl = this.baseUrl;
+    const url = baseUrl + chapterUrl;
     const sourceId = this.sourceId;
 
     const result = await fetch(url);


### PR DESCRIPTION
# ReadWN Scraper Improvement
I noticed several old ReadWN related bug reports of chapters not loading that were hard to reproduce.
I found one I was able to reproduce.

I traced the issue down to the fact all the chapterUrls are actually generated procedurally in our script (1..2..3..), but sometimes authors use different naming schemes (001...002...003).

This is janky. So, to fix this, I made it more janky.

Based on my observations on ReadWN, the first hundred chapters comfortably display by default, In probably 90% of usecases, the issue will be ironed out by chapter 100. So I have as many chapters as it can generate according to the table of contents, and then resume procedural generation from where it left off until the latest chapter of the novel.

In the test case I had, this fixed the issue perfectly.
I tested some other random novels on the paired sources, and they did not appear to have any issues. 
As an added benefit, this allows partial chapters to display on the earlier chapters (25.26 or 5.5)

I am not aware of any cons compared to the current implementation, but if we could do a full table of contents pull that would be even better.

Fixes LNReader/lnreader-sources#448
Fixes LNReader/lnreader-sources#480
Fixes LNReader/lnreader-sources#479
Fixes LNReader/lnreader-sources#464 specifically, but won't fix it if there's chapter numbers off the first page written like this