### PR TITLE
Fix scroll to progress on downloaded chapters

### DIFF
--- a/src/screens/reader/ReaderScreen.js
+++ b/src/screens/reader/ReaderScreen.js
@@ -207,9 +207,11 @@ const ChapterContent = ({ route, navigation }) => {
 
   const scrollTo = useCallback(
     offsetY => {
-      webViewRef?.current.injectJavaScript(`(()=>{
-        window.scrollTo({top:${offsetY},behavior:'smooth',})
-      })()`);
+      requestAnimationFrame(() => {
+        webViewRef?.current.injectJavaScript(`(()=>{
+          window.scrollTo({top:${offsetY},behavior:'smooth',})
+        })()`);
+      });
     },
     [webViewRef],
   );


### PR DESCRIPTION
Fixes #593 

This delays the scroll call just enough that it correctly works with downloaded chapters.

https://github.com/LNReader/lnreader/assets/5789439/1a1d3eb1-558e-42fc-9890-fb8836facde3