### PR TITLE
fix(fetch): Add capacity to change UA string

### DIFF
--- a/src/sources/en/novelupdates.js
+++ b/src/sources/en/novelupdates.js
@@ -1,4 +1,5 @@
 import * as cheerio from 'cheerio';
+import { fetchApi, fetchHtml } from '@utils/fetch/fetch';
 import { defaultTo } from 'lodash-es';
 import { FilterInputs } from '../types/filterTypes';
 const sourceId = 50;
@@ -7,10 +8,8 @@ const sourceName = 'Novel Updates';
 
 const baseUrl = 'https://www.novelupdates.com/';
 
-let headers = new Headers({
-  'User-Agent':
-    "'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
-});
+const userAgent =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36';
 
 const getPopularNovelsUrl = (page, { showLatestNovels, filters }) => {
   let url = `${baseUrl}${
@@ -55,11 +54,7 @@ const getPopularNovelsUrl = (page, { showLatestNovels, filters }) => {
 const popularNovels = async (page, { showLatestNovels, filters }) => {
   const url = getPopularNovelsUrl(page, { showLatestNovels, filters });
 
-  const result = await fetch(url, {
-    method: 'GET',
-    headers: headers,
-  });
-  const body = await result.text();
+  const body = await fetchHtml({ url, sourceId, userAgent: userAgent });
 
   const loadedCheerio = cheerio.load(body);
 
@@ -89,11 +84,7 @@ const popularNovels = async (page, { showLatestNovels, filters }) => {
 const parseNovelAndChapters = async novelUrl => {
   const url = `${baseUrl}series/${novelUrl}`;
 
-  const result = await fetch(url, {
-    method: 'GET',
-    headers: headers,
-  });
-  const body = await result.text();
+  const body = await fetchHtml({ url, sourceId, userAgent: userAgent });
 
   let loadedCheerio = cheerio.load(body);
 
@@ -133,14 +124,15 @@ const parseNovelAndChapters = async novelUrl => {
   formData.append('mygrr', 0);
   formData.append('mypostid', parseInt(novelId, 10));
 
-  const data = await fetch(
-    'https://www.novelupdates.com/wp-admin/admin-ajax.php',
-    {
+  const data = await fetchApi({
+    url: 'https://www.novelupdates.com/wp-admin/admin-ajax.php',
+    init: {
       method: 'POST',
-      headers,
       body: formData,
     },
-  );
+    sourceId,
+    userAgent: userAgent,
+  });
   const text = await data.text();
 
   loadedCheerio = cheerio.load(text);
@@ -179,9 +171,13 @@ const parseChapter = async (novelUrl, chapterUrl) => {
 
   let chapterText = '';
 
-  result = await fetch(url, {
-    method: 'GET',
-    headers: headers,
+  result = await fetchApi({
+    url: url,
+    init: {
+      method: 'GET',
+    },
+    sourceId,
+    userAgent: userAgent,
   });
   body = await result.text();
 
@@ -318,11 +314,7 @@ const searchNovels = async searchTerm => {
   const url =
     'https://www.novelupdates.com/?s=' + searchTerm + '&post_type=seriesplans';
 
-  const res = await fetch(url, {
-    method: 'GET',
-    headers: headers,
-  });
-  const body = await res.text();
+  const body = await fetchHtml({ url, sourceId, userAgent: userAgent });
 
   const loadedCheerio = cheerio.load(body);
 

--- a/src/sources/en/novelupdates.js
+++ b/src/sources/en/novelupdates.js
@@ -54,7 +54,11 @@ const getPopularNovelsUrl = (page, { showLatestNovels, filters }) => {
 const popularNovels = async (page, { showLatestNovels, filters }) => {
   const url = getPopularNovelsUrl(page, { showLatestNovels, filters });
 
-  const body = await fetchHtml({ url, sourceId, userAgent: userAgent });
+  const body = await fetchHtml({
+    url,
+    sourceId,
+    init: { headers: { 'User-Agent': userAgent } },
+  });
 
   const loadedCheerio = cheerio.load(body);
 
@@ -84,7 +88,11 @@ const popularNovels = async (page, { showLatestNovels, filters }) => {
 const parseNovelAndChapters = async novelUrl => {
   const url = `${baseUrl}series/${novelUrl}`;
 
-  const body = await fetchHtml({ url, sourceId, userAgent: userAgent });
+  const body = await fetchHtml({
+    url,
+    sourceId,
+    init: { headers: { 'User-Agent': userAgent } },
+  });
 
   let loadedCheerio = cheerio.load(body);
 
@@ -129,9 +137,9 @@ const parseNovelAndChapters = async novelUrl => {
     init: {
       method: 'POST',
       body: formData,
+      headers: { 'User-Agent': userAgent },
     },
     sourceId,
-    userAgent: userAgent,
   });
   const text = await data.text();
 
@@ -175,7 +183,7 @@ const parseChapter = async (novelUrl, chapterUrl) => {
     url,
     sourceId,
     raw: true,
-    userAgent: userAgent,
+    init: { headers: { 'User-Agent': userAgent } },
   });
 
   // console.log(result.url);
@@ -311,7 +319,11 @@ const searchNovels = async searchTerm => {
   const url =
     'https://www.novelupdates.com/?s=' + searchTerm + '&post_type=seriesplans';
 
-  const body = await fetchHtml({ url, sourceId, userAgent: userAgent });
+  const body = await fetchHtml({
+    url,
+    sourceId,
+    init: { headers: { 'User-Agent': userAgent } },
+  });
 
   const loadedCheerio = cheerio.load(body);
 

--- a/src/sources/en/novelupdates.js
+++ b/src/sources/en/novelupdates.js
@@ -171,24 +171,12 @@ const parseChapter = async (novelUrl, chapterUrl) => {
 
   let chapterText = '';
 
-  result = await fetchApi({
-    url: url,
-    init: {
-      method: 'GET',
-    },
+  [result, body] = await fetchHtml({
+    url,
     sourceId,
+    raw: true,
     userAgent: userAgent,
   });
-  body = await result.text();
-
-  if (
-    result.includes('Enable JavaScript and cookies to continue') ||
-    result.includes('Checking if the site connection is secure')
-  ) {
-    throw Error(
-      "The app couldn't bypass the source's Cloudflare protection.\n\nOpen the source in WebView to bypass the Cloudflare protection.",
-    );
-  }
 
   // console.log(result.url);
 

--- a/src/sources/en/novelupdates.js
+++ b/src/sources/en/novelupdates.js
@@ -181,6 +181,15 @@ const parseChapter = async (novelUrl, chapterUrl) => {
   });
   body = await result.text();
 
+  if (
+    result.includes('Enable JavaScript and cookies to continue') ||
+    result.includes('Checking if the site connection is secure')
+  ) {
+    throw Error(
+      "The app couldn't bypass the source's Cloudflare protection.\n\nOpen the source in WebView to bypass the Cloudflare protection.",
+    );
+  }
+
   // console.log(result.url);
 
   // console.log("Redirected URL: ", result.url);

--- a/src/sources/en/novelupdates.js
+++ b/src/sources/en/novelupdates.js
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio';
-import { fetchApi, fetchHtml } from '@utils/fetch/fetch';
+import { fetchApi, fetchHtml, cloudflareCheck } from '@utils/fetch/fetch';
 import { defaultTo } from 'lodash-es';
 import { FilterInputs } from '../types/filterTypes';
 const sourceId = 50;
@@ -179,12 +179,16 @@ const parseChapter = async (novelUrl, chapterUrl) => {
 
   let chapterText = '';
 
-  [result, body] = await fetchHtml({
+  result = await fetchApi({
     url,
+    init: {
+      method: 'GET',
+      headers: { 'User-Agent': userAgent },
+    },
     sourceId,
-    raw: true,
-    init: { headers: { 'User-Agent': userAgent } },
   });
+  body = await result.text();
+  cloudflareCheck(body);
 
   // console.log(result.url);
 

--- a/src/utils/fetch/fetch.ts
+++ b/src/utils/fetch/fetch.ts
@@ -1,23 +1,35 @@
 import { getSourceStorage } from '@hooks/useSourceStorage';
 
 export const defaultUserAgentString =
-  'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Mobile Safari/537.36';
+  'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Mobile Safari/537.36';
 
 interface FetchParams {
   url: string;
   init?: RequestInit;
   sourceId?: number;
+  userAgent?: string;
 }
 
 export const fetchApi = async ({
   url,
   init,
   sourceId,
+  userAgent,
 }: FetchParams): Promise<Response> => {
-  const headers = new Headers({
-    ...init?.headers,
-    'User-Agent': defaultUserAgentString,
-  });
+  let headers: Headers;
+  if (!userAgent) {
+    userAgent = defaultUserAgentString;
+  }
+  if (userAgent === '') {
+    headers = new Headers({
+      ...init?.headers,
+    });
+  } else {
+    headers = new Headers({
+      ...init?.headers,
+      'User-Agent': userAgent,
+    });
+  }
 
   if (sourceId) {
     const { cookies = '' } = getSourceStorage(sourceId);

--- a/src/utils/fetch/fetch.ts
+++ b/src/utils/fetch/fetch.ts
@@ -20,7 +20,7 @@ export const fetchApi = async ({
   if (!userAgent) {
     userAgent = defaultUserAgentString;
   }
-  if (userAgent === '') {
+  if (userAgent === 'false') {
     headers = new Headers({
       ...init?.headers,
     });

--- a/src/utils/fetch/fetch.ts
+++ b/src/utils/fetch/fetch.ts
@@ -8,6 +8,7 @@ interface FetchParams {
   init?: RequestInit;
   sourceId?: number;
   userAgent?: string;
+  raw?: Boolean;
 }
 
 export const fetchApi = async ({
@@ -42,7 +43,9 @@ export const fetchApi = async ({
   return fetch(url, { ...init, headers });
 };
 
-export const fetchHtml = async (params: FetchParams): Promise<string> => {
+export const fetchHtml = async (
+  params: FetchParams,
+): Promise<string | Array<any>> => {
   const res = await fetchApi(params);
   const html = await res.text();
 
@@ -55,5 +58,9 @@ export const fetchHtml = async (params: FetchParams): Promise<string> => {
     );
   }
 
-  return html;
+  if (params.raw === true) {
+    return [res, html];
+  } else {
+    return html;
+  }
 };

--- a/src/utils/fetch/fetch.ts
+++ b/src/utils/fetch/fetch.ts
@@ -4,33 +4,25 @@ export const defaultUserAgentString =
   'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Mobile Safari/537.36';
 
 interface FetchParams {
-  url: string;
-  init?: RequestInit;
-  sourceId?: number;
-  userAgent?: string;
-  raw?: Boolean;
+  url: string; // URL of request
+  init?: RequestInit; // Variable for passing headers and other information
+  sourceId?: number; // ID number of source for cookies
+  raw?: Boolean; // for fetchHtml, allows returning array with response and html.
 }
 
 export const fetchApi = async ({
   url,
   init,
   sourceId,
-  userAgent,
 }: FetchParams): Promise<Response> => {
-  let headers: Headers;
-  if (!userAgent) {
-    userAgent = defaultUserAgentString;
-  }
-  if (userAgent === 'false') {
-    headers = new Headers({
-      ...init?.headers,
-    });
-  } else {
-    headers = new Headers({
-      ...init?.headers,
-      'User-Agent': userAgent,
-    });
-  }
+  let headers = new Headers({
+    'User-Agent': defaultUserAgentString,
+    ...init?.headers,
+  });
+  // 'User-Agent' can be overwritten by defining
+  // init: { headers: { 'User-Agent': 'New user agent!' } },
+  // You can have NO user agent by doing this:
+  // init: { headers: { 'User-Agent': undefined } },
 
   if (sourceId) {
     const { cookies = '' } = getSourceStorage(sourceId);


### PR DESCRIPTION
# Improves on Fetch.ts
1. Adjusted UA string to my UA string on my Pixel5A running Android 13. User Agents have become more obscured and generic, so having a very specific UA string will start to stand out.
2. Implemented the capacity to specify a unique user agent string, or remove it entirely. Now done by switching line order and adding comments.

Why, you ask, would I want to remove a user agent string? Because if there's no UA string you can get the page without lazy loading images, which can potentially make or break pulling images. Sure, I can just use a raw fetch, but that doesn't have cloudflare bypass. (Specifically for ReaperScans)
This is the best of both worlds, while still functioning as expected with existing scripts.

Theoretically fixes https://github.com/LNReader/lnreader-sources/issues/473 but webview crashes my emulator.
Did several test loads to see if I saw any unexpected errors produced by this conversion, but wasn't able to find any.

Good news: Throws proper errors when cloudflare can't be bypassed instead of giving broke chapters
Bad news: I don't think it's getting the cookie for the bypass.