### PR TITLE
Fix: wrong mincroll in Update, History. TS Reader, Navigation (Main)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,6 +17,7 @@ module.exports = function (api) {
             '@plugins': './src/plugins',
             '@utils': './src/utils',
             '@theme': './src/theme',
+            '@navigators': './src/navigators',
           },
         },
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@react-native-community/slider": "4.2.3",
         "@react-native-cookies/cookies": "^6.2.1",
         "@react-native-picker/picker": "2.4.9",
-        "@react-navigation/drawer": "^6.0.1",
         "@react-navigation/material-bottom-tabs": "^6.0.9",
         "@react-navigation/native": "^6.0.6",
         "@react-navigation/stack": "^6.0.11",
@@ -4994,25 +4993,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@react-navigation/drawer": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-6.6.2.tgz",
-      "integrity": "sha512-6qt4guBdz7bkdo/8BLSCcFNdQdSPYyNn05D9cD+VCY3mGThSiD8bRiP9ju+64im7LsSU+bNWXaP8RxA/FtTVQg==",
-      "dependencies": {
-        "@react-navigation/elements": "^1.3.17",
-        "color": "^4.2.3",
-        "warn-once": "^0.1.0"
-      },
-      "peerDependencies": {
-        "@react-navigation/native": "^6.0.0",
-        "react": "*",
-        "react-native": "*",
-        "react-native-gesture-handler": ">= 1.0.0",
-        "react-native-reanimated": ">= 1.0.0",
-        "react-native-safe-area-context": ">= 3.0.0",
-        "react-native-screens": ">= 3.0.0"
       }
     },
     "node_modules/@react-navigation/elements": {
@@ -21674,16 +21654,6 @@
         "query-string": "^7.1.3",
         "react-is": "^16.13.0",
         "use-latest-callback": "^0.1.5"
-      }
-    },
-    "@react-navigation/drawer": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-6.6.2.tgz",
-      "integrity": "sha512-6qt4guBdz7bkdo/8BLSCcFNdQdSPYyNn05D9cD+VCY3mGThSiD8bRiP9ju+64im7LsSU+bNWXaP8RxA/FtTVQg==",
-      "requires": {
-        "@react-navigation/elements": "^1.3.17",
-        "color": "^4.2.3",
-        "warn-once": "^0.1.0"
       }
     },
     "@react-navigation/elements": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14734,9 +14734,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-native": {
-      "version": "0.69.6",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.6.tgz",
-      "integrity": "sha512-wwXpqM+12kdEYdBZCJUb5SBu95CzgejrwFeYJ78RzHZV/Sj6DBRekbsHGrDDsY4R25QXALQxy4DQYQCObVvWjA==",
+      "version": "0.69.11",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.11.tgz",
+      "integrity": "sha512-lYSzyDicrE5FLag+Vaq1XmPscQFKFqiUCsDMNkgd+wW9139u3hDEnbEWnXfM/kgF3vrKQUfyLMwfkuLV8EQfug==",
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
         "@react-native-community/cli": "^8.0.4",
@@ -28982,9 +28982,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-native": {
-      "version": "0.69.6",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.6.tgz",
-      "integrity": "sha512-wwXpqM+12kdEYdBZCJUb5SBu95CzgejrwFeYJ78RzHZV/Sj6DBRekbsHGrDDsY4R25QXALQxy4DQYQCObVvWjA==",
+      "version": "0.69.11",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.11.tgz",
+      "integrity": "sha512-lYSzyDicrE5FLag+Vaq1XmPscQFKFqiUCsDMNkgd+wW9139u3hDEnbEWnXfM/kgF3vrKQUfyLMwfkuLV8EQfug==",
       "requires": {
         "@jest/create-cache-key-function": "^27.0.1",
         "@react-native-community/cli": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@react-native-community/slider": "4.2.3",
     "@react-native-cookies/cookies": "^6.2.1",
     "@react-native-picker/picker": "2.4.9",
-    "@react-navigation/drawer": "^6.0.1",
     "@react-navigation/material-bottom-tabs": "^6.0.9",
     "@react-navigation/native": "^6.0.6",
     "@react-navigation/stack": "^6.0.11",

--- a/src/database/queries/ChapterQueries.ts
+++ b/src/database/queries/ChapterQueries.ts
@@ -513,6 +513,7 @@ FROM
 JOIN
   Novel
 ON Chapter.novelId = Novel.id AND Chapter.updatedTime IS NOT NULL
+ORDER BY Chapter.updatedTime DESC
 `;
 
 export const getUpdatesFromDb = (): Promise<Update[]> => {

--- a/src/hooks/githubUpdateChecker.ts
+++ b/src/hooks/githubUpdateChecker.ts
@@ -1,28 +1,33 @@
 import { useState, useEffect } from 'react';
 import { appVersion } from '../utils/versionUtils';
 
-export const useGithubUpdateChecker = () => {
+interface GithubUpdate {
+  isNewVersion: boolean;
+  latestRelease: any;
+}
+
+export const useGithubUpdateChecker = (): GithubUpdate => {
   const latestReleaseUrl =
     'https://api.github.com/repos/rajarsheechatterjee/lnreader/releases/latest';
 
   const [checking, setChecking] = useState(true);
-  const [latestRelease, setLatestRelease] = useState();
+  const [latestRelease, setLatestRelease] = useState<any>();
 
   const checkForRelease = async () => {
-    let res = await fetch(latestReleaseUrl);
-    res = await res.json();
+    const res = await fetch(latestReleaseUrl);
+    const data = await res.json();
 
     const release = {
-      tag_name: res.tag_name,
-      body: res.body,
-      downloadUrl: res.assets[0].browser_download_url,
+      tag_name: data.tag_name,
+      body: data.body,
+      downloadUrl: data.assets[0].browser_download_url,
     };
 
     setLatestRelease(release);
     setChecking(false);
   };
 
-  const isNewVersion = versionTag => {
+  const isNewVersion = (versionTag: string) => {
     let currentVersion = `${appVersion}`;
     const regex = /[^\\d.]/;
 
@@ -47,5 +52,10 @@ export const useGithubUpdateChecker = () => {
     };
 
     return data;
+  } else {
+    return {
+      latestRelease: undefined,
+      isNewVersion: false,
+    };
   }
 };

--- a/src/navigators/Main.tsx
+++ b/src/navigators/Main.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect } from 'react';
 
-import { NavigationContainer } from '@react-navigation/native';
+import {
+  DefaultTheme,
+  NavigationContainer,
+  Theme,
+} from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
 import { setBarColor } from '../theme/utils/setBarColor';
@@ -31,8 +35,9 @@ import { useAppDispatch } from '@redux/hooks';
 import { updateLibraryAction } from '@redux/updates/updates.actions';
 import { useSettings } from '@hooks/reduxHooks';
 import WebviewScreen from '@screens/WebviewScreen/WebviewScreen';
+import { RootStackParamList } from './types';
 
-const Stack = createStackNavigator();
+const Stack = createStackNavigator<RootStackParamList>();
 
 const MainNavigator = () => {
   const theme = useTheme();
@@ -55,10 +60,17 @@ const MainNavigator = () => {
     }
   }, []);
 
-  const { isNewVersion, latestRelease } = useGithubUpdateChecker() || {};
-
+  const { isNewVersion, latestRelease } = useGithubUpdateChecker();
+  const navigationTheme: Theme = {
+    dark: theme.isDark,
+    colors: {
+      ...DefaultTheme.colors,
+      primary: theme.primary,
+      background: theme.background,
+    },
+  };
   return (
-    <NavigationContainer theme={{ colors: theme }}>
+    <NavigationContainer theme={navigationTheme}>
       {isNewVersion && <NewUpdateDialog newVersion={latestRelease} />}
       <Stack.Navigator screenOptions={{ headerShown: false }}>
         <Stack.Screen name="BottomNavigator" component={BottomNavigator} />

--- a/src/navigators/Main.tsx
+++ b/src/navigators/Main.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect } from 'react';
 
-import {
-  DefaultTheme,
-  NavigationContainer,
-  Theme,
-} from '@react-navigation/native';
+import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
 import { setBarColor } from '../theme/utils/setBarColor';
@@ -61,16 +57,9 @@ const MainNavigator = () => {
   }, []);
 
   const { isNewVersion, latestRelease } = useGithubUpdateChecker();
-  const navigationTheme: Theme = {
-    dark: theme.isDark,
-    colors: {
-      ...DefaultTheme.colors,
-      primary: theme.primary,
-      background: theme.background,
-    },
-  };
+
   return (
-    <NavigationContainer theme={navigationTheme}>
+    <NavigationContainer theme={{ colors: theme }}>
       {isNewVersion && <NewUpdateDialog newVersion={latestRelease} />}
       <Stack.Navigator screenOptions={{ headerShown: false }}>
         <Stack.Screen name="BottomNavigator" component={BottomNavigator} />

--- a/src/navigators/types/index.ts
+++ b/src/navigators/types/index.ts
@@ -25,7 +25,11 @@ export type RootStackParamList = {
   Migration: undefined;
   SourceNovels: { pluginId: string };
   MigrateNovel: { pluginId: string; novel: any };
-  WebviewScreen: undefined;
+  WebviewScreen: {
+    pluginId: string;
+    name: string;
+    url: string;
+  };
 };
 
 export type ChapterScreenProps = StackScreenProps<
@@ -35,4 +39,8 @@ export type ChapterScreenProps = StackScreenProps<
 export type BrowseSourceScreenProps = StackScreenProps<
   RootStackParamList,
   'SourceScreen'
+>;
+export type WebviewScreenProps = StackScreenProps<
+  RootStackParamList,
+  'WebviewScreen'
 >;

--- a/src/navigators/types/index.ts
+++ b/src/navigators/types/index.ts
@@ -1,0 +1,38 @@
+import { ChapterInfo } from '@database/types';
+import { StackScreenProps } from '@react-navigation/stack';
+
+export type RootStackParamList = {
+  BottomNavigator: undefined;
+  Novel: { name: string; url: string; pluginId: string };
+  Chapter: {
+    novel: {
+      id: string;
+      pluginId: string;
+      name: string;
+    };
+    chapter: ChapterInfo;
+  };
+  MoreStack: undefined;
+  SourceScreen: {
+    pluginId: string;
+    pluginName: string;
+    pluginUrl: string;
+    showLatestNovels: boolean;
+  };
+  BrowseMal: undefined;
+  BrowseSettings: undefined;
+  GlobalSearchScreen: { searchText: string } | undefined;
+  Migration: undefined;
+  SourceNovels: { pluginId: string };
+  MigrateNovel: { pluginId: string; novel: any };
+  WebviewScreen: undefined;
+};
+
+export type ChapterScreenProps = StackScreenProps<
+  RootStackParamList,
+  'Chapter'
+>;
+export type BrowseSourceScreenProps = StackScreenProps<
+  RootStackParamList,
+  'SourceScreen'
+>;

--- a/src/screens/BrowseSourceScreen/BrowseSourceScreen.tsx
+++ b/src/screens/BrowseSourceScreen/BrowseSourceScreen.tsx
@@ -20,19 +20,9 @@ import { switchNovelToLibrary } from '@database/queries/NovelQueries';
 import { NovelInfo } from '@database/types';
 import SourceScreenSkeletonLoading from '@screens/browse/loadingAnimation/SourceScreenSkeletonLoading';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BrowseSourceScreenProps } from '@navigators/types';
 
-interface BrowseSourceScreenProps {
-  route: {
-    params: {
-      pluginId: string;
-      pluginName: string;
-      pluginUrl: string;
-      showLatestNovels?: boolean;
-    };
-  };
-}
-
-const BrowseSourceScreen: React.FC<BrowseSourceScreenProps> = ({ route }) => {
+const BrowseSourceScreen = ({ route }: BrowseSourceScreenProps) => {
   const theme = useTheme();
   const { navigate, goBack } = useNavigation();
   const previousScreen = usePreviousRouteName();

--- a/src/screens/WebviewScreen/WebviewScreen.tsx
+++ b/src/screens/WebviewScreen/WebviewScreen.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import WebView from 'react-native-webview';
 import CookieManager from '@react-native-cookies/cookies';
 
@@ -7,22 +6,12 @@ import { Appbar } from '@components';
 import { useTheme } from '@hooks/useTheme';
 import useSourceStorage from '@hooks/useSourceStorage';
 import { defaultUserAgentString } from '@utils/fetch/fetch';
+import { WebviewScreenProps } from '@navigators/types';
 
-type ReaderScreenRouteProps = RouteProp<{
-  params: {
-    name: string;
-    pluginId: string;
-    url: string;
-  };
-}>;
-
-const WebviewScreen = () => {
+const WebviewScreen = ({ route, navigation }: WebviewScreenProps) => {
   const theme = useTheme();
-  const { goBack } = useNavigation();
 
-  const {
-    params: { name, pluginId, url },
-  } = useRoute<ReaderScreenRouteProps>();
+  const { name, pluginId, url } = route.params;
   const { setSourceStorage } = useSourceStorage({ pluginId });
 
   useEffect(() => {
@@ -37,7 +26,12 @@ const WebviewScreen = () => {
 
   return (
     <>
-      <Appbar mode="small" title={name} handleGoBack={goBack} theme={theme} />
+      <Appbar
+        mode="small"
+        title={name}
+        handleGoBack={() => navigation.goBack()}
+        theme={theme}
+      />
       <WebView
         startInLoadingState
         userAgent={defaultUserAgentString}

--- a/src/screens/browse/components/PluginCard.tsx
+++ b/src/screens/browse/components/PluginCard.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
 import { StyleSheet, Text, View, Image, Pressable } from 'react-native';
 
-import { getString } from '@strings/translations';
-import { Button, IconButtonV2 } from '@components';
+import { IconButtonV2 } from '@components';
 
 import { coverPlaceholderColor } from '@theme/colors';
 import { ThemeColors } from '@theme/types';
 
 import { PluginItem } from '@plugins/types';
-import {
-  installPlugin,
-  uninstallPlugin,
-  updatePlugin,
-} from '@plugins/pluginManager';
+import { installPlugin } from '@plugins/pluginManager';
+import { PluginMenu } from './PluginMenu';
 
 interface Props {
   installed: boolean;
@@ -46,50 +42,25 @@ const PluginCard: React.FC<Props> = ({
       <Image source={{ uri: plugin.iconUrl }} style={styles.icon} />
       <View style={styles.details}>
         <Text style={{ color: theme.onSurface }}>{plugin.name}</Text>
-        <Text style={[{ color: theme.onSurfaceVariant }, styles.lang]}>
-          {`ID: ${plugin.id}\n${plugin.lang}\nVer: ${plugin.version}`}
+        <Text style={{ color: theme.onSurface, fontWeight: 'bold' }}>
+          {`ID: ${plugin.id}`}
+        </Text>
+        <Text style={[{ color: theme.onSurfaceVariant }]}>
+          {`${plugin.lang}\n${plugin.version}`}
         </Text>
       </View>
     </View>
     <View style={styles.flexRow}>
       {installed ? (
-        <>
-          <Button
-            title={getString('browseScreen.latest')}
-            textColor={theme.primary}
-            onPress={() => navigateToSource(plugin, true)}
-          />
-          <IconButtonV2
-            name={isPinned ? 'pin' : 'pin-outline'}
-            size={22}
-            color={isPinned ? theme.primary : theme.onSurfaceVariant}
-            onPress={() => onTogglePinSource(plugin)}
-            theme={theme}
-          />
-          <IconButtonV2
-            name={'arrow-up-circle'}
-            size={22}
-            color={theme.primary}
-            onPress={() => {
-              updatePlugin(plugin).then(updated => {
-                if (updated) {
-                  plugin.version = updated.version;
-                  onUpdatePlugin(plugin);
-                }
-              });
-            }}
-            theme={theme}
-          />
-          <IconButtonV2
-            name={'delete'}
-            size={22}
-            color={theme.primary}
-            onPress={() =>
-              uninstallPlugin(plugin).then(() => onUninstallPlugin(plugin))
-            }
-            theme={theme}
-          />
-        </>
+        <PluginMenu
+          plugin={plugin}
+          isPinned={isPinned}
+          theme={theme}
+          onTogglePinSource={onTogglePinSource}
+          navigateToSource={navigateToSource}
+          onUninstallPlugin={onUninstallPlugin}
+          onUpdatePlugin={onUpdatePlugin}
+        />
       ) : (
         <>
           <IconButtonV2
@@ -129,9 +100,6 @@ const styles = StyleSheet.create({
   },
   details: {
     marginLeft: 16,
-  },
-  lang: {
-    fontSize: 12,
   },
   flexRow: {
     flexDirection: 'row',

--- a/src/screens/browse/components/PluginMenu.tsx
+++ b/src/screens/browse/components/PluginMenu.tsx
@@ -1,0 +1,114 @@
+import { StyleSheet } from 'react-native';
+import { Divider, Menu, overlay } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
+import React, { useState } from 'react';
+import { Button, IconButtonV2 } from '@components';
+import { PluginItem } from '@plugins/types';
+import { uninstallPlugin, updatePlugin } from '@plugins/pluginManager';
+import { getString } from '@strings/translations';
+import { ThemeColors } from '@theme/types';
+
+interface PluginMenuProps {
+  plugin: PluginItem;
+  isPinned: boolean;
+  theme: ThemeColors;
+  onTogglePinSource: (plugin: PluginItem) => void;
+  navigateToSource: (plugin: PluginItem, showLatestNovels?: boolean) => void;
+  onUninstallPlugin: (plugin: PluginItem) => void;
+  onUpdatePlugin: (plugin: PluginItem) => void;
+}
+
+export const PluginMenu: React.FC<PluginMenuProps> = ({
+  plugin,
+  isPinned,
+  theme,
+  onTogglePinSource,
+  navigateToSource,
+  onUninstallPlugin,
+  onUpdatePlugin,
+}) => {
+  const [visible, setVisible] = useState(false);
+  const showMenu = () => setVisible(true);
+  const hideMenu = () => setVisible(false);
+  const { navigate } = useNavigation();
+
+  return (
+    <Menu
+      visible={visible}
+      onDismiss={hideMenu}
+      anchor={
+        <IconButtonV2
+          name={'dots-vertical'}
+          size={30}
+          color={isPinned ? theme.primary : theme.onSurfaceVariant}
+          onPress={showMenu}
+          theme={theme}
+        />
+      }
+      contentStyle={[
+        { backgroundColor: overlay(2, theme.surface) },
+        styles.menu,
+      ]}
+    >
+      <Button
+        title={getString('browseScreen.latest')}
+        textColor={theme.primary}
+        onPress={() => navigateToSource(plugin, true)}
+      />
+      <Divider
+        style={[{ backgroundColor: theme.onSurfaceDisabled }, styles.divider]}
+      />
+      <Button
+        title={isPinned ? 'Unpin' : 'Pin'}
+        icon={isPinned ? 'pin' : 'pin-outline'}
+        textColor={isPinned ? theme.primary : theme.onSurfaceVariant}
+        onPress={() => onTogglePinSource(plugin)}
+      />
+      <Button
+        title="Update"
+        icon={'arrow-up-circle'}
+        textColor={theme.primary}
+        onPress={() => {
+          updatePlugin(plugin).then(updated => {
+            if (updated) {
+              plugin.version = updated.version;
+              onUpdatePlugin(plugin);
+            }
+          });
+        }}
+      />
+      <Button
+        title="Visit"
+        icon={'earth'}
+        textColor={theme.primary}
+        onPress={() => {
+          navigate('WebviewScreen', {
+            pluginId: plugin.id,
+            name: plugin.name,
+            url: plugin.site,
+          });
+        }}
+      />
+      <Divider
+        style={[{ backgroundColor: theme.onSurfaceDisabled }, styles.divider]}
+      />
+      <Button
+        title="Uninstall"
+        icon={'delete'}
+        onPress={() =>
+          uninstallPlugin(plugin).then(() => onUninstallPlugin(plugin))
+        }
+      />
+    </Menu>
+  );
+};
+
+const styles = StyleSheet.create({
+  menu: {
+    width: 150,
+  },
+  divider: {
+    height: 1,
+    marginBottom: 5,
+  },
+});

--- a/src/screens/reader/ReaderScreen.js
+++ b/src/screens/reader/ReaderScreen.js
@@ -90,6 +90,7 @@ const ChapterContent = ({ route, navigation }) => {
   const [sourceChapter, setChapter] = useState({ ...chapter });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState();
+  const [[nextChapter, prevChapter], setAdjacentChapter] = useState([]);
 
   const emmiter = useRef(
     new NativeEventEmitter(NativeModules.VolumeButtonListener),
@@ -135,7 +136,11 @@ const ChapterContent = ({ route, navigation }) => {
 
   const getChapter = async () => {
     try {
-      const chapterText = await getChapterFromDB(chapter.id);
+      const [chapterText, nextChap, prevChap] = await Promise.all([
+        getChapterFromDB(chapter.id),
+        getNextChapter(chapter.novelId, chapter.id),
+        getPrevChapter(chapter.novelId, chapter.id),
+      ]);
       if (chapterText) {
         sourceChapter.chapterText = chapterText;
       } else {
@@ -163,18 +168,6 @@ const ChapterContent = ({ route, navigation }) => {
       });
     }
   }, []);
-
-  const [[nextChapter, prevChapter], setAdjacentChapter] = useState([]);
-  useEffect(() => {
-    const setPrevAndNextChap = async () => {
-      const [nextChap, prevChap] = await Promise.all([
-        getNextChapter(chapter.novelId, chapter.id),
-        getPrevChapter(chapter.novelId, chapter.id),
-      ]);
-      setAdjacentChapter([nextChap, prevChap]);
-    };
-    setPrevAndNextChap();
-  }, [chapter]);
 
   const [ttsStatus, startTts] = useTextToSpeech(
     htmlToText(sourceChapter.chapterText).split('\n'),

--- a/src/screens/reader/ReaderScreen.tsx
+++ b/src/screens/reader/ReaderScreen.tsx
@@ -1,10 +1,14 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Dimensions, NativeModules, NativeEventEmitter } from 'react-native';
+import {
+  Dimensions,
+  NativeModules,
+  NativeEventEmitter,
+  DrawerLayoutAndroid,
+} from 'react-native';
 
 import VolumeButtonListener from '@utils/volumeButtonListener';
 
 import { useDispatch } from 'react-redux';
-import { Portal } from 'react-native-paper';
 import { useKeepAwake } from 'expo-keep-awake';
 
 import {
@@ -35,34 +39,47 @@ import { defaultTo } from 'lodash-es';
 import BottomInfoBar from './components/BottomInfoBar/BottomInfoBar';
 import { sanitizeChapterText } from './utils/sanitizeChapterText';
 import ChapterDrawer from './components/ChapterDrawer';
-import { createDrawerNavigator } from '@react-navigation/drawer';
 import { htmlToText } from '@plugins/helpers/htmlToText';
 import ChapterLoadingScreen from './ChapterLoadingScreen/ChapterLoadingScreen';
 import { ErrorScreenV2 } from '@components';
+import { ChapterScreenProps } from '@navigators/types';
+import { ChapterInfo } from '@database/types';
+import WebView, { WebViewNavigation } from 'react-native-webview';
 
-const Chapter = ({ route }) => {
-  const DrawerNav = createDrawerNavigator();
+const Chapter = ({ route, navigation }: ChapterScreenProps) => {
+  const drawerRef = useRef<DrawerLayoutAndroid>(null);
   return (
-    <DrawerNav.Navigator
-      params={route.params}
-      drawerContent={props => <ChapterDrawer {...props} />}
+    <DrawerLayoutAndroid
+      ref={drawerRef}
+      drawerWidth={300}
+      drawerPosition="left"
+      renderNavigationView={() => (
+        <ChapterDrawer route={route} navigation={navigation} />
+      )}
     >
-      <DrawerNav.Screen
-        name="ChapterContent"
-        initialParams={route.params}
-        options={{ headerShown: false }}
-        component={ChapterContent}
+      <ChapterContent
+        route={route}
+        navigation={navigation}
+        drawerRef={drawerRef}
       />
-    </DrawerNav.Navigator>
+    </DrawerLayoutAndroid>
   );
 };
 
-const ChapterContent = ({ route, navigation }) => {
+type ChapterContentProps = ChapterScreenProps & {
+  drawerRef: React.RefObject<DrawerLayoutAndroid>;
+};
+
+export const ChapterContent = ({
+  route,
+  navigation,
+  drawerRef,
+}: ChapterContentProps) => {
   useKeepAwake();
   const params = route.params;
   const { novel, chapter } = params;
-  let webViewRef = useRef(null);
-  let readerSheetRef = useRef(null);
+  const webViewRef = useRef<WebView>(null);
+  const readerSheetRef = useRef(null);
 
   const theme = useTheme();
   const dispatch = useDispatch();
@@ -82,15 +99,19 @@ const ChapterContent = ({ route, navigation }) => {
 
   const [hidden, setHidden] = useState(true);
   const position = usePosition(chapter.novelId, chapter.id);
-  const minScroll = useRef(0);
+  const minScroll = useRef<number>(0);
 
   const { tracker, trackedNovels } = useTrackingStatus();
-  const isTracked = trackedNovels.find(obj => obj.novel.id === chapter.novelId);
+  const isTracked = trackedNovels.find(
+    (obj: any) => obj.novel.id === chapter.novelId,
+  );
 
-  const [sourceChapter, setChapter] = useState({ ...chapter });
+  const [sourceChapter, setChapter] = useState({ ...chapter, chapterText: '' });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState();
-  const [[nextChapter, prevChapter], setAdjacentChapter] = useState([]);
+  const [[nextChapter, prevChapter], setAdjacentChapter] = useState<
+    ChapterInfo[]
+  >([]);
 
   const emmiter = useRef(
     new NativeEventEmitter(NativeModules.VolumeButtonListener),
@@ -99,13 +120,13 @@ const ChapterContent = ({ route, navigation }) => {
   const connectVolumeButton = () => {
     VolumeButtonListener.connect();
     VolumeButtonListener.preventDefault();
-    emmiter.current.addListener('VolumeUp', e => {
+    emmiter.current.addListener('VolumeUp', () => {
       webViewRef.current?.injectJavaScript(`(()=>{
           window.scrollBy({top:${-Dimensions.get('window')
             .height},behavior:'smooth',})
         })()`);
     });
-    emmiter.current.addListener('VolumeDown', e => {
+    emmiter.current.addListener('VolumeDown', () => {
       webViewRef.current?.injectJavaScript(`(()=>{
           window.scrollBy({top:${
             Dimensions.get('window').height
@@ -130,7 +151,7 @@ const ChapterContent = ({ route, navigation }) => {
     };
   }, [useVolumeButtons, chapter]);
 
-  const onLayout = useCallback(e => {
+  const onLayout = useCallback(() => {
     setTimeout(() => connectVolumeButton());
   }, []);
 
@@ -150,7 +171,8 @@ const ChapterContent = ({ route, navigation }) => {
         );
       }
       setChapter(sourceChapter);
-    } catch (e) {
+      setAdjacentChapter([nextChap, prevChap]);
+    } catch (e: any) {
       setError(e.message);
       showToast(e.message);
     } finally {
@@ -159,7 +181,7 @@ const ChapterContent = ({ route, navigation }) => {
   };
 
   useEffect(() => {
-    getChapter(chapter.id);
+    getChapter();
     if (!incognitoMode) {
       insertHistory(chapter.id);
       dispatch({
@@ -180,15 +202,15 @@ const ChapterContent = ({ route, navigation }) => {
   );
 
   const scrollTo = useCallback(
-    offsetY => {
-      webViewRef?.current.injectJavaScript(`(()=>{
+    (offsetY: number) => {
+      webViewRef.current?.injectJavaScript(`(()=>{
         window.scrollTo({top:${offsetY},behavior:'smooth',})
       })()`);
     },
     [webViewRef],
   );
 
-  let scrollInterval;
+  let scrollInterval: NodeJS.Timer;
   useEffect(() => {
     if (autoScroll) {
       scrollInterval = setInterval(() => {
@@ -219,7 +241,7 @@ const ChapterContent = ({ route, navigation }) => {
   };
 
   const doSaveProgress = useCallback(
-    (offsetY, percentage) => {
+    (offsetY: number, percentage: number) => {
       if (!incognitoMode) {
         dispatch(
           saveScrollPosition(offsetY, percentage, chapter.id, chapter.novelId),
@@ -244,29 +266,29 @@ const ChapterContent = ({ route, navigation }) => {
     setHidden(!hidden);
   };
 
-  const navigateToChapterBySwipe = name => {
+  const navigateToChapterBySwipe = (actionName: string) => {
     let navChapter;
-    if (name === 'SWIPE_LEFT') {
+    if (actionName === 'SWIPE_LEFT') {
       navChapter = nextChapter;
-    } else if (name === 'SWIPE_RIGHT') {
+    } else if (actionName === 'SWIPE_RIGHT') {
       navChapter = prevChapter;
     } else {
       return;
     }
-    // you can add more condition for friendly usage. for example: if(name === "SWIPE_LEFT" || name === "right")
+
     navChapter
       ? navigation.replace('Chapter', {
           novel: novel,
           chapter: navChapter,
         })
       : showToast(
-          name === 'SWIPE_LEFT'
+          actionName === 'SWIPE_LEFT'
             ? "There's no next chapter"
             : "There's no previous chapter",
         );
   };
 
-  const onWebViewNavigationStateChange = async ({ url }) => {
+  const onWebViewNavigationStateChange = async ({ url }: WebViewNavigation) => {
     if (url !== 'about:blank') {
       setLoading(true);
       const res = await fetchChapter(novel.pluginId, chapter.url);
@@ -280,10 +302,10 @@ const ChapterContent = ({ route, navigation }) => {
     removeExtraParagraphSpacing,
     pluginId: novel.pluginId,
   });
-  const openDrawer = () => {
-    navigation.openDrawer();
+  const openDrawer = useCallback(() => {
+    drawerRef.current?.openDrawer();
     setHidden(true);
-  };
+  }, [drawerRef]);
 
   if (loading) {
     return <ChapterLoadingScreen />;
@@ -296,7 +318,7 @@ const ChapterContent = ({ route, navigation }) => {
   return (
     <>
       <WebViewReader
-        chapterInfo={{ novel, chapter }}
+        data={{ novel, chapter }}
         html={chapterText}
         chapterName={chapter.name}
         swipeGestures={swipeGestures}
@@ -313,9 +335,7 @@ const ChapterContent = ({ route, navigation }) => {
         onWebViewNavigationStateChange={onWebViewNavigationStateChange}
       />
       <BottomInfoBar
-        scrollPercentage={
-          position?.percentage || Math.round(minScroll.current) || 0
-        }
+        scrollPercentage={position?.percentage || Math.round(minScroll.current)}
       />
       <ReaderBottomSheetV2 bottomSheetRef={readerSheetRef} />
       {!hidden && (

--- a/src/screens/reader/ReaderScreen.tsx
+++ b/src/screens/reader/ReaderScreen.tsx
@@ -241,7 +241,7 @@ export const ChapterContent = ({
   };
 
   const doSaveProgress = useCallback(
-    (offsetY: number, percentage: number) => {
+    async (offsetY: number, percentage: number) => {
       if (!incognitoMode) {
         dispatch(
           saveScrollPosition(offsetY, percentage, chapter.id, chapter.novelId),
@@ -327,7 +327,7 @@ export const ChapterContent = ({
         webViewRef={webViewRef}
         onLayout={() => {
           useVolumeButtons && onLayout();
-          scrollTo(position?.offsetY);
+          scrollTo(position?.offsetY || 1);
         }}
         onPress={hideHeader}
         doSaveProgress={doSaveProgress}

--- a/src/screens/reader/components/ChapterDrawer.js
+++ b/src/screens/reader/components/ChapterDrawer.js
@@ -11,13 +11,13 @@ import { useNovel, useSettings, usePreferences } from '@hooks/reduxHooks';
 import { useDispatch } from 'react-redux';
 import { getNovelAction } from '@redux/novel/novel.actions';
 
-const ChapterDrawer = ({ state: st, navigation }) => {
+const ChapterDrawer = ({ route, navigation }) => {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
   const styles = createStylesheet(theme, insets);
   let listRef = useRef();
   const dispatch = useDispatch();
-  const { chapter, novel: novelItem } = st.routes[0].params;
+  const { chapter, novel: novelItem } = route.params;
   const { defaultChapterSort = 'ORDER BY id ASC' } = useSettings();
   const { sort = defaultChapterSort, filter = '' } = usePreferences(
     chapter.novelId,

--- a/src/screens/reader/components/ReaderSeekBar.js
+++ b/src/screens/reader/components/ReaderSeekBar.js
@@ -122,7 +122,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     zIndex: 2,
     right: -(Dimensions.get('window').width / 2) + 40,
-    bottom: 300,
+    bottom: Dimensions.get('window').height / 2,
   },
   horizontalSliderContainer: {
     position: 'absolute',

--- a/src/screens/reader/components/ReaderSeekBar.js
+++ b/src/screens/reader/components/ReaderSeekBar.js
@@ -16,8 +16,7 @@ const VerticalScrollbar = ({
   const { bottom } = useSafeAreaInsets();
   const onSlidingComplete = value => {
     let offsetY =
-      ((value - Math.round(minScroll)) * Dimensions.get('window').height) /
-      Math.round(minScroll);
+      ((value - minScroll) * Dimensions.get('window').height) / minScroll;
     scrollTo(offsetY);
   };
   const screenOrientation = useDeviceOrientation();
@@ -37,17 +36,17 @@ const VerticalScrollbar = ({
             transform: [{ rotate: '-90deg' }],
           }}
         >
-          {percentage || Math.round(minScroll)}
+          {percentage || minScroll}
         </Text>
         <Slider
           style={{
             flex: 1,
             height: 40,
           }}
-          minimumValue={Math.round(minScroll)}
+          minimumValue={minScroll}
           maximumValue={100}
           step={1}
-          value={percentage || Math.round(minScroll)}
+          value={percentage || minScroll}
           onSlidingComplete={onSlidingComplete}
           thumbTintColor={theme.primary}
           minimumTrackTintColor={theme.primary}
@@ -81,17 +80,17 @@ const VerticalScrollbar = ({
             marginLeft: 16,
           }}
         >
-          {percentage || Math.round(minScroll)}
+          {percentage || minScroll}
         </Text>
         <Slider
           style={{
             flex: 1,
             height: 40,
           }}
-          minimumValue={Math.round(minScroll)}
+          minimumValue={minScroll}
           maximumValue={100}
           step={1}
-          value={percentage || Math.round(minScroll)}
+          value={percentage || minScroll}
           onSlidingComplete={onSlidingComplete}
           thumbTintColor={theme.primary}
           minimumTrackTintColor={theme.primary}

--- a/src/screens/reader/components/WebViewReader.tsx
+++ b/src/screens/reader/components/WebViewReader.tsx
@@ -209,7 +209,7 @@ const WebViewReader: React.FC<WebViewReaderProps> = props => {
                       type: 'hide',
                     })}>
                       <chapter 
-                        data-plugin-id='${novel?.pluginId}'
+                        data-plugin-id='${novel.pluginId}'
                         data-novel-id='${chapter.novelId}'
                         data-chapter-id='${chapter.id}'
                       >
@@ -233,6 +233,9 @@ const WebViewReader: React.FC<WebViewReaderProps> = props => {
                           )}</div>`
                     }
                     <script>
+                      const pluginId = '${novel.pluginId}';
+                      const novelId = '${chapter.novelId}';
+                      const chapterId = '${chapter.id}';
                       if(!document.querySelector("input[offline]") && ${
                         plugin?.protected
                       }){

--- a/src/screens/reader/components/WebViewReader.tsx
+++ b/src/screens/reader/components/WebViewReader.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Dimensions, StatusBar } from 'react-native';
-import WebView from 'react-native-webview';
+import WebView, { WebViewNavigation } from 'react-native-webview';
 
 import { useTheme } from '@hooks/useTheme';
-import { ChapterInfo, NovelInfo } from '@database/types';
+import { ChapterInfo } from '@database/types';
 import { useReaderSettings } from '@redux/hooks';
 import { getString } from '@strings/translations';
 
@@ -15,18 +15,25 @@ type WebViewPostEvent = {
 };
 
 type WebViewReaderProps = {
-  chapterInfo: { novel: NovelInfo; chapter: ChapterInfo };
+  data: {
+    novel: {
+      id: string;
+      pluginId: string;
+      name: string;
+    };
+    chapter: ChapterInfo;
+  };
   html: string;
   chapterName: string;
   swipeGestures: boolean;
   minScroll: React.MutableRefObject<number>;
   nextChapter: ChapterInfo;
-  webViewRef: React.MutableRefObject<WebView>;
+  webViewRef: React.RefObject<WebView>;
   onPress(): void;
   onLayout(): void;
   doSaveProgress(offSetY: number, percentage: number): void;
   navigateToChapterBySwipe(name: string): void;
-  onWebViewNavigationStateChange(): void;
+  onWebViewNavigationStateChange({ url }: WebViewNavigation): void;
 };
 
 const onClickWebViewPostMessage = (event: WebViewPostEvent) =>
@@ -36,7 +43,7 @@ const onClickWebViewPostMessage = (event: WebViewPostEvent) =>
 
 const WebViewReader: React.FC<WebViewReaderProps> = props => {
   const {
-    chapterInfo,
+    data,
     html,
     chapterName,
     swipeGestures,
@@ -51,7 +58,7 @@ const WebViewReader: React.FC<WebViewReaderProps> = props => {
   } = props;
 
   const theme = useTheme();
-  const { novel, chapter } = chapterInfo;
+  const { novel, chapter } = data;
   const readerSettings = useReaderSettings();
   const { theme: backgroundColor } = readerSettings;
 

--- a/src/screens/reader/components/WebViewReader.tsx
+++ b/src/screens/reader/components/WebViewReader.tsx
@@ -85,7 +85,13 @@ const WebViewReader: React.FC<WebViewReaderProps> = props => {
               plugin.fetchImage(event.data).then(base64 => {
                 webViewRef.current?.injectJavaScript(
                   `document.querySelector("img[delayed-src='${event.data}']").src="data:image/jpg;base64,${base64}";
-                  document.querySelector("img[delayed-src='${event.data}']").classList.remove("load-icon");`,
+                  document.querySelector("img[delayed-src='${event.data}']").classList.remove("load-icon");
+                  window.requestAnimationFrame(() => {
+                    window.ReactNativeWebView.postMessage(
+                      JSON.stringify({type: "height", data: document.body.scrollHeight})
+                    );
+                  });
+                  `,
                 );
               });
             }
@@ -212,13 +218,23 @@ const WebViewReader: React.FC<WebViewReaderProps> = props => {
                         ${html}
                       </chapter>
                     </div>
+                    <div class="infoText">
+                    ${getString(
+                      'readerScreen.finished',
+                    )}: ${chapterName?.trim()}
+                    </div>
+                    ${
+                      nextChapter
+                        ? `<button class="nextButton" ${onClickWebViewPostMessage(
+                            { type: 'next' },
+                          )}>
+                      Next: ${nextChapter.name}
+                    </button>`
+                        : `<div class="infoText">${getString(
+                            'readerScreen.noNextChapter',
+                          )}</div>`
+                    }
                     <script>
-                      new ResizeObserver(() =>
-                        window.ReactNativeWebView.postMessage(
-                          JSON.stringify({type: "height", data: document.body.scrollHeight})
-                        )
-                      ).observe(document.querySelector('body'));
-
                       if(!document.querySelector("input[offline]") && ${
                         plugin?.protected
                       }){
@@ -244,23 +260,12 @@ const WebViewReader: React.FC<WebViewReaderProps> = props => {
                           );
                         }, 100);
                       });
+                      window.onload = () => {
+                        window.ReactNativeWebView.postMessage(
+                          JSON.stringify({type: "height", data: document.body.scrollHeight})
+                        );
+                      }
                     </script>
-                    <div class="infoText">
-                    ${getString(
-                      'readerScreen.finished',
-                    )}: ${chapterName?.trim()}
-                    </div>
-                    ${
-                      nextChapter
-                        ? `<button class="nextButton" ${onClickWebViewPostMessage(
-                            { type: 'next' },
-                          )}>
-                      Next: ${nextChapter.name}
-                    </button>`
-                        : `<div class="infoText">${getString(
-                            'readerScreen.noNextChapter',
-                          )}</div>`
-                    }
                     ${
                       swipeGestures
                         ? `
@@ -282,7 +287,6 @@ const WebViewReader: React.FC<WebViewReaderProps> = props => {
                           </script>`
                         : ''
                     }
-
                     <script>
                       async function fn(){${readerSettings.customJS}}
                       document.addEventListener("DOMContentLoaded", fn);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
       "@utils/*": ["src/utils/*"],
       "@plugins/*": ["src/plugins/*"],
       "@services/*": ["src/services/*"],
+      "@navigators/*": ["src/navigators/*"],
     }
   },
   "exclude": [


### PR DESCRIPTION
- Fix: When try opening chapters from Update or History screen, reader (with full of images) gave wrong value of document height to app (1100 instead of 8100).
The small one is height of content without rendered images. So I think somehow images were lazy load for these screens.
-> update minscroll pararelly with postion. 
- TypeScript: Because of old Drawer Navigation is quite mess, it's not Stack Screen nor Drawer Screen. It's both :( 
So I replaced by DrawerLayoutAndroid (very same).
- Current theme is conflicting with NavigationContainer. only 2 attributes matched.
- Fetch ChapterText, prev, next chapter at the same time. Because `nextChapter` coming up later which make whole reader re-render. Looks kinda bad. I will add index for chapter and maybe also download, so time is not a big deal. 
- Add three dots button for Browse Screen.
- Fixed vertical seekbar postion for tab device