### PR TITLE
fix search error when query contains '

### DIFF
--- a/src/database/queries/LibraryQueries.ts
+++ b/src/database/queries/LibraryQueries.ts
@@ -63,6 +63,8 @@ export const getLibrary = ({
   }
 
   if (searchText) {
+    searchText = searchText.replace(/'/g, "\\'");
+
     query += ` AND novelName LIKE '%${searchText}%'`;
   }
 


### PR DESCRIPTION
This fixes a sql escaping bug which crashes the global search functionality when query contains character '

![Screenshot_2023-11-12-11-42-59-42_3c1c179116822eec69c21805387f0489](https://github.com/LNReader/lnreader/assets/16373480/00e64449-cb11-4cf8-ba3c-ab5f060d66c9)
![Screenshot_2023-11-12-11-43-02-94_3c1c179116822eec69c21805387f0489](https://github.com/LNReader/lnreader/assets/16373480/61ae59e9-e81e-4afb-98ae-bc0a1c2919c7)



It was previously submitted as PR #496 but I had to delete that repositiry and redo it.

