### PR TITLE
fix cloudflare on novelupdates

### DIFF
--- a/src/sources/en/novelupdates.js
+++ b/src/sources/en/novelupdates.js
@@ -1,8 +1,12 @@
 import * as cheerio from 'cheerio';
-import { fetchApi, fetchHtml, cloudflareCheck } from '@utils/fetch/fetch';
+import {
+  fetchApi,
+  fetchHtml,
+  cloudflareCheck,
+  defaultUserAgentString,
+} from '@utils/fetch/fetch';
 import { defaultTo } from 'lodash-es';
 import { FilterInputs } from '../types/filterTypes';
-import { defaultUserAgentString } from '@utils/fetch/fetch';
 
 const sourceId = 50;
 

--- a/src/sources/en/novelupdates.js
+++ b/src/sources/en/novelupdates.js
@@ -2,14 +2,15 @@ import * as cheerio from 'cheerio';
 import { fetchApi, fetchHtml, cloudflareCheck } from '@utils/fetch/fetch';
 import { defaultTo } from 'lodash-es';
 import { FilterInputs } from '../types/filterTypes';
+import { defaultUserAgentString } from '@utils/fetch/fetch';
+
 const sourceId = 50;
 
 const sourceName = 'Novel Updates';
 
 const baseUrl = 'https://www.novelupdates.com/';
 
-const userAgent =
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36';
+const userAgent = defaultUserAgentString;
 
 const getPopularNovelsUrl = (page, { showLatestNovels, filters }) => {
   let url = `${baseUrl}${


### PR DESCRIPTION
cloudflare requires the same cf_clearance cookie + ip address + user-agent as the webview
novelupdates.js was using the wrong user-agent which caused errors when novelupdates had cloudflare turned on and when the app navigated to a website using cloudflare (ex. foxaholic)

![image](https://github.com/LNReader/lnreader/assets/91645046/f47ec51f-ccbc-4611-bab9-fec963fa021c)


fixes https://github.com/LNReader/lnreader-sources/issues/669 and https://github.com/LNReader/lnreader/issues/818