### PR TITLE
remove mmkv cookie storage, use native cookie storage (cloudflare)

### DIFF
--- a/src/screens/WebviewScreen/WebviewScreen.tsx
+++ b/src/screens/WebviewScreen/WebviewScreen.tsx
@@ -1,11 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import WebView from 'react-native-webview';
-import CookieManager from '@react-native-cookies/cookies';
-
 import { Appbar } from '@components';
 import { useTheme } from '@hooks/useTheme';
-import useSourceStorage from '@hooks/useSourceStorage';
 import { defaultUserAgentString } from '@utils/fetch/fetch';
 
 type ReaderScreenRouteProps = RouteProp<{
@@ -21,19 +18,8 @@ const WebviewScreen = () => {
   const { goBack } = useNavigation();
 
   const {
-    params: { name, sourceId, url },
+    params: { name, url },
   } = useRoute<ReaderScreenRouteProps>();
-  const { setSourceStorage } = useSourceStorage({ sourceId });
-
-  useEffect(() => {
-    CookieManager.get(url, true).then(cookies => {
-      const cloudflareCookie = cookies?.cf_clearance;
-      if (cloudflareCookie) {
-        const cloudflareCookieString = `${cloudflareCookie.name}=${cloudflareCookie.value}`;
-        setSourceStorage('cookies', cloudflareCookieString);
-      }
-    });
-  }, []);
 
   return (
     <>

--- a/src/screens/WebviewScreen/WebviewScreen.tsx
+++ b/src/screens/WebviewScreen/WebviewScreen.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import WebView from 'react-native-webview';
+import CookieManager from '@react-native-cookies/cookies';
+
 import { Appbar } from '@components';
 import { useTheme } from '@hooks/useTheme';
 import { defaultUserAgentString } from '@utils/fetch/fetch';
-import CookieManager from '@react-native-cookies/cookies';
 
 type ReaderScreenRouteProps = RouteProp<{
   params: {

--- a/src/screens/WebviewScreen/WebviewScreen.tsx
+++ b/src/screens/WebviewScreen/WebviewScreen.tsx
@@ -4,6 +4,7 @@ import WebView from 'react-native-webview';
 import { Appbar } from '@components';
 import { useTheme } from '@hooks/useTheme';
 import { defaultUserAgentString } from '@utils/fetch/fetch';
+import CookieManager from '@react-native-cookies/cookies';
 
 type ReaderScreenRouteProps = RouteProp<{
   params: {
@@ -21,6 +22,10 @@ const WebviewScreen = () => {
     params: { name, url },
   } = useRoute<ReaderScreenRouteProps>();
 
+  const syncCookies = () => {
+    CookieManager.flush();
+  };
+
   return (
     <>
       <Appbar mode="small" title={name} handleGoBack={goBack} theme={theme} />
@@ -28,6 +33,7 @@ const WebviewScreen = () => {
         startInLoadingState
         userAgent={defaultUserAgentString}
         source={{ uri: url }}
+        onNavigationStateChange={syncCookies}
       />
     </>
   );

--- a/src/utils/fetch/fetch.ts
+++ b/src/utils/fetch/fetch.ts
@@ -1,5 +1,3 @@
-import { getSourceStorage } from '@hooks/useSourceStorage';
-
 export const defaultUserAgentString =
   'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Mobile Safari/537.36';
 
@@ -27,7 +25,6 @@ export const cloudflareCheck = (text: string) => {
 export const fetchApi = async ({
   url,
   init,
-  sourceId,
 }: FetchParams): Promise<Response> => {
   let headers = new Headers({
     'User-Agent': defaultUserAgentString,
@@ -37,14 +34,6 @@ export const fetchApi = async ({
   // init: { headers: { 'User-Agent': 'New user agent!' } },
   // You can have NO user agent by doing this:
   // init: { headers: { 'User-Agent': undefined } },
-
-  if (sourceId) {
-    const { cookies = '' } = getSourceStorage(sourceId);
-
-    if (cookies) {
-      headers.append('cookie', cookies);
-    }
-  }
 
   return fetch(url, { ...init, headers });
 };


### PR DESCRIPTION
1. fetch on react native is made by the native networking stack so the cookie is stored in the device itself, no need for mmkv storage: https://stackoverflow.com/questions/41132167/react-native-fetch-cookie-persist

2. android syncs the cookies every 5 min, if the app is killed during that time, the cookies will be lost and cloudflare will trigger again, we can fix this by using CookieManager.flush() to force cookie sync when the nav state changes on webview (occurs when cloudflare passes and navigates to website)

3. the old implementation in useEffect was not storing any cookies because it is called right when webview opens and tries to obtain cookies before cloudflare ran, we needed to wait 5-10 seconds for the cloudflare pass to obtain the cf_clearance cookie and write to mmkv source storage