### PR TITLE
fix: hide progressbar

### DIFF
--- a/src/screens/reader/ReaderScreen.tsx
+++ b/src/screens/reader/ReaderScreen.tsx
@@ -291,8 +291,8 @@ export const ChapterContent = ({
 
   const openDrawer = useCallback(() => {
     drawerRef.current?.openDrawer();
-    setHidden(true);
-  }, [drawerRef]);
+    hideHeader();
+  }, [drawerRef, hideHeader]);
 
   if (loading) {
     return <ChapterLoadingScreen />;


### PR DESCRIPTION
Progressbar kept being displayed after opening the chapterDrawer if it was opened through the ReaderFooter