### PR TITLE
Improve "Remove extra paragraph spacing" feature

### DIFF
--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -34,7 +34,7 @@ export const sanitizeChapterText = (
       text = text
         .replace(/([\u200B-\u200D\uFEFF])(?<=<p>\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>\s*(?=<\/?p>)/g, '')
+        .replace(/<br>\s*(?=<\/?p>)/g, '');
     }
   } else {
     text = getString('readerScreen.emptyChapterMessage');

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -32,11 +32,11 @@ export const sanitizeChapterText = (
   if (text) {
     if (options?.removeExtraParagraphSpacing) {
       text = text
-      .replace(/[\u200B-\u200D\uFEFF]/g, '')
-      .replace(/<br>\s*(?=<\/p>)/g, '')
-      .replace(/<br>\s*(?<=\/p><br>)(?=<p>)/g, '')
-      .replace(/(?:<br>\s*<\/?br>)+/g, '')
-      .replace(/\n\n+/g, '\n');
+        .replace(/[\u200B-\u200D\uFEFF]/g, '')
+        .replace(/<br>\s*(?=<\/p>)/g, '')
+        .replace(/<br>\s*(?<=\/p><br>)(?=<p>)/g, '')
+        .replace(/(?:<br>\s*<\/?br>)+/g, '')
+        .replace(/\n\n+/g, '\n');
     }
   } else {
     text = getString('readerScreen.emptyChapterMessage');

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -34,6 +34,7 @@ export const sanitizeChapterText = (
       text = text
       .replace(/[\u200B-\u200D\uFEFF]/g, '')
       .replace(/<br>\s*(?=<\/p>)/g, '')
+      .replace(/<br>\s*(?<=\/p><br>)(?=<p>)/g, '')
       .replace(/(?:<br>\s*<\/?br>)+/g, '')
       .replace(/\n\n+/g, '\n');
     }

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -34,7 +34,7 @@ export const sanitizeChapterText = (
       text = text
         .replace(/[\u200B-\u200D\uFEFF]/g, '')
         .replace(/<br>\s*(?=<\/p>)/g, '')
-        .replace(/<br>\s*(?<=<\/p>\s*<br>)(?=<p>)/g, '')
+        .replace(/<br>(?<=<\/p>\s*<br>)\s*(?=<p>)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(/\n\n+/g, '\n');
     }

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -33,8 +33,8 @@ export const sanitizeChapterText = (
     if (options?.removeExtraParagraphSpacing) {
       text = text
         .replace(/[\u200B-\u200D\uFEFF]/g, '')
-        .replace(/<br>(?<=<\/p>\s*<br>|)\s*(?=<\/?p>)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
+        .replace(/<br>\s*(?=<\/?p>)/g, '')
         .replace(/\n\n+/g, '\n');
     }
   } else {

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -33,8 +33,7 @@ export const sanitizeChapterText = (
     if (options?.removeExtraParagraphSpacing) {
       text = text
         .replace(/[\u200B-\u200D\uFEFF]/g, '')
-        .replace(/<br>\s*(?=<\/p>)/g, '')
-        .replace(/<br>(?<=<\/p>\s*<br>)\s*(?=<p>)/g, '')
+        .replace(/<br>(?<=<\/p>\s*<br>|)\s*(?=<\/?p>)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(/\n\n+/g, '\n');
     }

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -32,7 +32,7 @@ export const sanitizeChapterText = (
   if (text) {
     if (options?.removeExtraParagraphSpacing) {
       text = text
-        .replace(/[\u200B-\u200D\uFEFF]/g, '')
+        .replace(/([\u200B-\u200D\uFEFF])(?<=<p>\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(/<br>\s*(?=<\/?p>)/g, '')
         .replace(/\n\n+/g, '\n');

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -34,7 +34,7 @@ export const sanitizeChapterText = (
       text = text
         .replace(/[\u200B-\u200D\uFEFF]/g, '')
         .replace(/<br>\s*(?=<\/p>)/g, '')
-        .replace(/<br>\s*(?<=\/p><br>)(?=<p>)/g, '')
+        .replace(/<br>\s*(?<=<\/p>\s*<br>)(?=<p>)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(/\n\n+/g, '\n');
     }

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -31,7 +31,11 @@ export const sanitizeChapterText = (
   });
   if (text) {
     if (options?.removeExtraParagraphSpacing) {
-      text = text.replace(/<\s*br[^>]*>/gi, '\n').replace(/\n{2,}/g, '\n\n');
+      text = text
+      .replace(/[\u200B-\u200D\uFEFF]/g, '')
+      .replace(/<br>\s*(?=<\/p>)/g, '')
+      .replace(/(?:<br>\s*<\/?br>)+/g, '')
+      .replace(/\n\n+/g, '\n');
     }
   } else {
     text = getString('readerScreen.emptyChapterMessage');

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -35,7 +35,6 @@ export const sanitizeChapterText = (
         .replace(/([\u200B-\u200D\uFEFF])(?<=<p>\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(/<br>\s*(?=<\/?p>)/g, '')
-        .replace(/\n\n+/g, '\n');
     }
   } else {
     text = getString('readerScreen.emptyChapterMessage');


### PR DESCRIPTION
Currently, it just removes all ``<br>``.
With this change you could:
-remove excessive br
-remove some zero-width spaces (I found a novel that put them in a p to simulate an extra empty paragraph).
-remove a br after the end of a p. It's just extra space.
-remove a br present right before the end of a p.