### PR TITLE
Decrease reader progress bar font-size

### DIFF
--- a/android/app/src/main/assets/css/index.css
+++ b/android/app/src/main/assets/css/index.css
@@ -184,7 +184,7 @@ td {
   border-radius: 1.2rem;
   background-color: var(--theme-surface-0-9);
   touch-action: none;
-  font-size: 16px;
+  font-size: 14px;
   user-select: none;
 }
 


### PR DESCRIPTION
From 16px to 14px.
It's better looking.

Current:
![Screenshot_20240719-023204_1](https://github.com/user-attachments/assets/0872914c-3231-4b4c-9667-ed24954012c2)

Modified(commit):
![Screenshot_20240719-023128_1](https://github.com/user-attachments/assets/00a01d50-6159-4d7f-aa85-59c472570c7c)

Stable 1.1.19:
![Screenshot_20240719-023232_1](https://github.com/user-attachments/assets/240fd0fb-5e97-4f8c-b597-b2a5a5725a06)
