### PR TITLE
Improve "Remove extra paragraph spacing" feature

### DIFF
--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -19,7 +19,6 @@ export const sanitizeChapterText = (
       'div',
       'ol',
       'li',
-      'title',
     ]),
     allowedAttributes: {
       'img': ['src', 'class', 'id'],
@@ -32,7 +31,10 @@ export const sanitizeChapterText = (
   });
   if (text) {
     if (options?.removeExtraParagraphSpacing) {
-      text = text.replace(/<\s*br[^>]*>/gi, '\n').replace(/\n{2,}/g, '\n\n');
+      text = text
+        .replace(/([\u200B-\u200D\uFEFF])(?<=<p>\1)/g, '')
+        .replace(/(?:<br>\s*<\/?br>)+/g, '')
+        .replace(/<br>\s*(?=<\/?p>)/g, '');
     }
   } else {
     text = getString('readerScreen.emptyChapterMessage');


### PR DESCRIPTION
repost of #1105, closed by mistake.
Currently, it just removes all ``<br>``.
With this change you could:
-remove excessive br
-remove some zero-width spaces (I found a novel that put them in a p to simulate an extra empty paragraph).
-remove a br after the end of a p. It's just extra space.
-remove a br present right before the end of a p.