### PR TITLE
Progress bar - better proportions

### DIFF
--- a/android/app/src/main/assets/css/index.css
+++ b/android/app/src/main/assets/css/index.css
@@ -160,7 +160,7 @@ td {
 #ToolWrapper > #ScrollBar {
   margin-top: 8px;
   width: 2.4rem;
-  height: 45vh;
+  height: 50vh;
   min-height: 200px;
   border-radius: 1.2rem;
   background-color: var(--theme-surface-0-9);
@@ -218,7 +218,7 @@ td {
 
 #ToolWrapper.horizontal > #ScrollBar {
   display: flex;
-  width: 80vw;
+  width: 95.5vw;
   height: 2.4rem;
   min-height: unset;
   align-items: center;


### PR DESCRIPTION
Since the tts buttons has been replaced by the bubble version, it's now possible.
Proportions taken based on Stable 1.1.19 except vertical (shorter than stable, longer than current beta)
If you want to make vertical like stable the height values is around 55vh
Current:
![image](https://github.com/user-attachments/assets/a57fa0cc-a224-4a99-9274-3c55ca21c33b)
![image](https://github.com/user-attachments/assets/8c7f53c5-2d24-4c0c-94af-69e4e14b8072)

Modified (commit):
![image](https://github.com/user-attachments/assets/376f6779-6b8c-499e-b656-9be7ea586db5)
![image](https://github.com/user-attachments/assets/ef55bb2a-ca2b-4d43-bb5f-5114b9d865d0)
