### PR TITLE
 Improve "Remove extra paragraph spacing" feature

### DIFF
--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -465,7 +465,10 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
-      html = html.replace(/<\s*br[^>]*>/gi, '\n').replace(/\n{2,}/g, '\n\n');
+      html = html
+        .replace(/([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p>\1)/g, '')
+        .replace(/(?:<br>\s*<\/?br>)+/g, '')
+        .replace(/<br>\s*(?=<\/?p>)/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
-        .replace(/(?:<br>\s*<\/?br>\s*)+(?=<\/?(?:p|h[1-5])\b[^>]*>)/g, '')
+        .replace(/(?:<br>\s*<\/?br>\s*)+(?=<\/?(?:p|h[1-5]|br)\b[^>]*>)/g, '')
         .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(
-          /([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class\"[^>]+)?>\1)/g,
+          /([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class\"[^>]+)?>\s*\1)/g,
           '',
         )
         .replace(/(?:<br>\s*<\/?br>)+/g, '')

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -472,10 +472,7 @@ window.addEventListener('DOMContentLoaded', async () => {
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<)|(?<=>\s*<br>\s*<\/?br>\s*))/g,
           '',
         )//look-around double br. If a tag is near, delete the double br.
-        .replace(
-          /<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g,
-          '',
-        );
+        .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -468,10 +468,7 @@ window.addEventListener('DOMContentLoaded', async () => {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(
-          /<br>(?:(?=<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g,
-          '',
-        );
+        .replace(/<br>(?:(?=<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,10 +466,10 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(&nbsp;)(?<=<p(?: class\"[^>]+)?>\s*\1)/g, '')
+        .replace(/(&nbsp;)(?<=<p(?:[^>]*)?>\s*\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(
-          /<br>(?:(?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))\s*/g,
+          /<br>(?:(?=<\/?p(?:[^>]*)?>)|(?<=<\/?p>\s*<br>))\s*/g,
           '',
         );
     }

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,10 +466,10 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(&nbsp;)(?<=<p(?:[^>]*)?>\s*\1)/g, '')
+        .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(
-          /<br>(?:(?=<\/?p(?:[^>]*)?>)|(?<=<\/?p>\s*<br>))\s*/g,
+          /<br>(?:(?=<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g,
           '',
         );
     }

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -471,7 +471,10 @@ window.addEventListener('DOMContentLoaded', async () => {
           '',
         )
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>((?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))\s*/g, '')
+        .replace(
+          /<br>((?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))\s*/g,
+          '',
+        );
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
-        .replace(/(?:<br>\s*<\/?br>\s*)+(?![^<])/g, '')
+        .replace(/(?:<br>\s*<\/?br>\s*)+(?=<\/?(?:p|h[1-5])\b[^>]*>)/g, '')
         .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,7 +466,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(&nbsp;)(?<=<p(?: class\"[^>]+)?>\s*\1)/g, '')        
+        .replace(/(&nbsp;)(?<=<p(?: class\"[^>]+)?>\s*\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(
           /<br>(?:(?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))\s*/g,

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -471,7 +471,7 @@ window.addEventListener('DOMContentLoaded', async () => {
           '',
         )
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>[\s\u00a]*(?=<\/?p(?: class\"[^>]+)?>)/g, '');
+        .replace(/<br>(\s*(?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))/g, '')
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -469,7 +469,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         .replace(/(?:&nbsp;\s*)+(?=<\/?p[> ])/g, '')
         .replace(/<br>\s*<br>\s*(?:<br>\s*)+/g, '<br><br>') //force max 2 consecutive <br>, chaining regex
         .replace(
-          /<br>\s*<br>(?:(?!\s*<(?:em|[iab]|strong|span)[< ])|(?<!(?:\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))\s*/g,
+          /<br>\s*<br>(?:(?!\s*<(?:em|[iab]|strong|span)[> ])|(?<!(?:\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))\s*/g,
           '',
         ) //look-around double br. If certain tags aren't near, delete the double br.
         .replace(/<br>(?:(?=\s*<\/?p[> ])|(?<=<\/?p>\s*<br>))\s*/g, '');

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,9 +466,9 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class\"[^\>]+)?>\1)/g, '')
+        .replace(/([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class\"[^>]+)?>\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>\s*(?=<\/?p(?: class\"[^\>]+)?>)/g, '');
+        .replace(/<br>\s*(?=<\/?p(?: class\"[^>]+)?>)/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -472,7 +472,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         )
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(
-          /<br>((?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))\s*/g,
+          /<br>(?:(?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))\s*/g,
           '',
         );
     }

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
-        .replace(/<br>\s*<br>\s*(<br>\s*)+/g, '<br><br>') //force max 2 consecutive <br>, chaining regex
+        .replace(/<br>\s*<br>\s*(?:<br>\s*)+/g, '<br><br>') //force max 2 consecutive <br>, chaining regex
         .replace(
           /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))/g,
           '',

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
-        .replace(/(?:<br>\s*<\/?br>)+/g, '')
+        .replace(/(?:<br>\s*<\/?br>\s*)+(?![^<])/g, '')
         .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,13 +466,13 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
+        .replace(/(?:&nbsp;\s*)+(?=<\/?p[> ])/g, '')
         .replace(/<br>\s*<br>\s*(?:<br>\s*)+/g, '<br><br>') //force max 2 consecutive <br>, chaining regex
         .replace(
-          /<br>\s*<br>(?:(?!\s*<(?:em>|[iab]>|strong>|span>))|(?<!(?:\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))\s*/g,
+          /<br>\s*<br>(?:(?!\s*<(?:em|[iab]|strong|span)[< ])|(?<!(?:\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))\s*/g,
           '',
         ) //look-around double br. If certain tags aren't near, delete the double br.
-        .replace(/<br>(?:(?=\s*<\/?p\b[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
+        .replace(/<br>(?:(?=\s*<\/?p[> ])|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -471,7 +471,7 @@ window.addEventListener('DOMContentLoaded', async () => {
           '',
         )
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>\s*(?=<\/?p(?: class\"[^>]+)?>)/g, '');
+        .replace(/<br>[\s\u00a]*(?=<\/?p(?: class\"[^>]+)?>)/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
-        .replace(/(?<=<br>\s*<br>\s*)(?:<br>\s*)+/g, '') //force max 2 consecutive <br>, chaining regex
+        .replace(/(?<=<br>\s*<br>)\s*(?:<br>\s*)+/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
           /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))/g,
           '',

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -469,7 +469,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
         .replace(/<br>\s*<br>\s*(?:<br>\s*)+/g, '<br><br>') //force max 2 consecutive <br>, chaining regex
         .replace(
-          /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))\s*/g,
+          /<br>\s*<br>(?:(?!\s*<(?:em>|[iab]>|strong>|span>))|(?<!(?:\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))\s*/g,
           '',
         ) //look-around double br. If certain tags aren't near, delete the double br.
         .replace(/<br>(?:(?=\s*<\/?p\b[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,7 +466,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(?:&nbsp;)+(?=<\/?p[^>]*>)\s*/g, '')
+        .replace(/(?:&nbsp;)+(?=\s*<\/?p[^>]*>)\s*/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>\s*))/g,

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,6 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
+        .replace(/(?:<br>\s*<br>\s*)+(?=<br>\s*<br>)/g, '')
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!br>))|(?<=(?<!<br)>\s*<br>\s*<\/?br>\s*))/g,
           '',

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,7 +466,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(?:&nbsp;\s*)+(?=<\/?p[> ])/g, '')
+        .replace(/(?:&nbsp;\s*|[\u200b]\s*)+(?=<\/?p[> ])/g, '')
         .replace(/<br>\s*<br>\s*(?:<br>\s*)+/g, '<br><br>') //force max 2 consecutive <br>, chaining regex
         .replace(
           /<br>\s*<br>(?:(?!\s*<(?:em|[iab]|strong|span)[> ])|(?<!(?:\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))\s*/g,

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(
-          /([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class\"[^>]+)?>\s*\1)/g,
+          /(&nbsp;)(?<=<p(?: class\"[^>]+)?>\s*\1)/g,
           '',
         )
         .replace(/(?:<br>\s*<\/?br>)+/g, '')

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,7 +466,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
+        .replace(/(?:&nbsp;\s*)+(?=<\/?p[^>]*>)/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '')
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<)|(?<=>\s*<br>\s*<\/?br>\s*))/g,

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,11 +467,11 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(?:&nbsp;\s*)+(?=<\/?p[^>]*>)/g, '')
-        .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '')//force max 2 consecutive <br>, chaining regex
+        .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<)|(?<=>\s*<br>\s*<\/?br>\s*))/g,
           '',
-        )//look-around double br. If a tag is near, delete the double br.
+        ) //look-around double br. If a tag is near, delete the double br.
         .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -469,7 +469,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
-          /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>\s*))/g,
+          /<br>\s*<\/?br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>))/g,
           '',
         ) //look-around double br. If certain tags aren't near, delete the double br.
         .replace(/<br>(?:(?=\s*<\/?p\b[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -468,7 +468,7 @@ window.addEventListener('DOMContentLoaded', async () => {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>(?:(?=<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
+        .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,7 +466,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(?:&nbsp;)+(?=\s*<\/?p\b[^>]*>)\s*/g, '')
+        .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>\s*))/g,

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -471,7 +471,7 @@ window.addEventListener('DOMContentLoaded', async () => {
           '',
         )
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>(\s*(?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))/g, '')
+        .replace(/<br>((?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))\s*/g, '')
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
-        .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
+        .replace(/(?<=<br>\s*<br>\s*)(?:<br>\s*)+/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
           /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))/g,
           '',

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -469,7 +469,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
-          /<br>\s*<\/?br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>))/g,
+          /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>))/g,
           '',
         ) //look-around double br. If certain tags aren't near, delete the double br.
         .replace(/<br>(?:(?=\s*<\/?p\b[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,8 +467,14 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
-        .replace(/(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!br>))|(?<=(?<!<br)>\s*<br>\s*<\/?br>\s*))/g, '')
-        .replace(/<br>(?:(?=\s*<\/?p[^>]*>|\s*<br>\s*<br>)|(?<=<\/?p>\s*<br>))\s*/g, '');
+        .replace(
+          /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!br>))|(?<=(?<!<br)>\s*<br>\s*<\/?br>\s*))/g,
+          '',
+        )
+        .replace(
+          /<br>(?:(?=\s*<\/?p[^>]*>|\s*<br>\s*<br>)|(?<=<\/?p>\s*<br>))\s*/g,
+          '',
+        );
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
-        .replace(/(?:<br>\s*<br>\s*)+(?=<br>\s*<br>)/g, '')
+        .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '')
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!br>))|(?<=(?<!<br)>\s*<br>\s*<\/?br>\s*))/g,
           '',

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,10 +466,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(
-          /(&nbsp;)(?<=<p(?: class\"[^>]+)?>\s*\1)/g,
-          '',
-        )
+        .replace(/(&nbsp;)(?<=<p(?: class\"[^>]+)?>\s*\1)/g, '')        
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
         .replace(
           /<br>(?:(?=<\/?p(?: class\"[^>]+)?>)|(?<=<\/?p>\s*<br>))\s*/g,

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -465,10 +465,13 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
-      html = html
-        .replace(/([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class\"[^>]+)?>\1)/g, '')
-        .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>\s*(?=<\/?p(?: class\"[^>]+)?>)/g, '');
+        html = html
+          .replace(
+            /([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class"[^>]+)?>\1)/g,
+            '',
+          )
+          .replace(/(?:<br>\s*<\/?br>)+/g, '')
+          .replace(/<br>\s*(?=<\/?p(?: class"[^>]+)?>)/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,9 +466,9 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p>\1)/g, '')
+        .replace(/([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class\"[^\>]+)?>\1)/g, '')
         .replace(/(?:<br>\s*<\/?br>)+/g, '')
-        .replace(/<br>\s*(?=<\/?p>)/g, '');
+        .replace(/<br>\s*(?=<\/?p(?: class\"[^\>]+)?>)/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,13 +467,13 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(?:&nbsp;\s*)+(?=<\/?p[^>]*>)/g, '')
-        .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '')
+        .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '')//force max 2 consecutive <br>, chaining regex
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<)|(?<=>\s*<br>\s*<\/?br>\s*))/g,
           '',
-        )
+        )//look-around double br. If a tag is near, delete the double br.
         .replace(
-          /<br>(?:(?=\s*<\/?p[^>]*>|\s*<br>\s*<br>)|(?<=<\/?p>\s*<br>))\s*/g,
+          /<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g,
           '',
         );
     }

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,7 +467,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
-        .replace(/(?<=<br>\s*<br>)\s*(?:<br>\s*)+/g, '') //force max 2 consecutive <br>, chaining regex
+        .replace(/<br>\s*<br>\s*(<br>\s*)+/g, '<br><br>') //force max 2 consecutive <br>, chaining regex
         .replace(
           /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))/g,
           '',

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -469,7 +469,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
-          /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>))/g,
+          /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))/g,
           '',
         ) //look-around double br. If certain tags aren't near, delete the double br.
         .replace(/<br>(?:(?=\s*<\/?p\b[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -469,7 +469,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '')
         .replace(
-          /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!br>))|(?<=(?<!<br)>\s*<br>\s*<\/?br>\s*))/g,
+          /(?:<br>\s*<\/?br>\s*)+(?:(?=<)|(?<=>\s*<br>\s*<\/?br>\s*))/g,
           '',
         )
         .replace(

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -469,9 +469,9 @@ window.addEventListener('DOMContentLoaded', async () => {
         .replace(/(?:&nbsp;\s*)+(?=<\/?p[^>]*>)/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
-          /(?:<br>\s*<\/?br>\s*)+(?:(?=<)|(?<=>\s*<br>\s*<\/?br>\s*))/g,
+          /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>\s*))/g,
           '',
-        ) //look-around double br. If a tag is near, delete the double br.
+        ) //look-around double br. If certain tags aren't near, delete the double br.
         .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -469,7 +469,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         .replace(/(?:&nbsp;\s*)+(?=<\/?p\b[^>]*>)/g, '')
         .replace(/<br>\s*<br>\s*(?:<br>\s*)+/g, '<br><br>') //force max 2 consecutive <br>, chaining regex
         .replace(
-          /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))/g,
+          /<br>\s*<br>(?:(?=\s*<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<br>))\s*/g,
           '',
         ) //look-around double br. If certain tags aren't near, delete the double br.
         .replace(/<br>(?:(?=\s*<\/?p\b[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,13 +466,13 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(?:&nbsp;)+(?=\s*<\/?p[^>]*>)\s*/g, '')
+        .replace(/(?:&nbsp;)+(?=\s*<\/?p\b[^>]*>)\s*/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>\s*))/g,
           '',
         ) //look-around double br. If certain tags aren't near, delete the double br.
-        .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
+        .replace(/<br>(?:(?=\s*<\/?p\b[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -465,13 +465,13 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
-        html = html
-          .replace(
-            /([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class"[^>]+)?>\1)/g,
-            '',
-          )
-          .replace(/(?:<br>\s*<\/?br>)+/g, '')
-          .replace(/<br>\s*(?=<\/?p(?: class"[^>]+)?>)/g, '');
+      html = html
+        .replace(
+          /([\u200B-\u200D\uFEFF]|&nbsp;)(?<=<p(?: class\"[^>]+)?>\1)/g,
+          '',
+        )
+        .replace(/(?:<br>\s*<\/?br>)+/g, '')
+        .replace(/<br>\s*(?=<\/?p(?: class\"[^>]+)?>)/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -467,8 +467,8 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
         .replace(/(&nbsp;)(?<=<p[^>]*>\s*\1)/g, '')
-        .replace(/(?:<br>\s*<\/?br>\s*)+(?=<\/?(?:p|h[1-5]|br)\b[^>]*>)/g, '')
-        .replace(/<br>(?:(?=\s*<\/?p[^>]*>)|(?<=<\/?p>\s*<br>))\s*/g, '');
+        .replace(/(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!br>))|(?<=(?<!<br)>\s*<br>\s*<\/?br>\s*))/g, '')
+        .replace(/<br>(?:(?=\s*<\/?p[^>]*>|\s*<br>\s*<br>)|(?<=<\/?p>\s*<br>))\s*/g, '');
     }
     reader.chapterElement.innerHTML = html;
   });

--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -466,7 +466,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (reader.generalSettings.val.removeExtraParagraphSpacing) {
       html = html
-        .replace(/(?:&nbsp;\s*)+(?=<\/?p[^>]*>)/g, '')
+        .replace(/(?:&nbsp;)+(?=<\/?p[^>]*>)\s*/g, '')
         .replace(/(?:<br>\s*)+(?=<br>\s*<br>)/g, '') //force max 2 consecutive <br>, chaining regex
         .replace(
           /(?:<br>\s*<\/?br>\s*)+(?:(?=<(?!em>|[iab]>|strong>|span>))|(?<=(?<!\/em|\/[iab]|\/strong|\/span)>\s*<br>\s*<\/?br>\s*))/g,


### PR DESCRIPTION
repost of #1164 due to conflicts (related code moved to another file)
Currently, it just removes all ``<br>``.
With this change you could:
-remove excessive ``<br>``
-remove some zero-width spaces and ``&nbsp;`` (I found a novel that put them in a p to simulate an extra empty paragraph).
-remove a br after the end of a p. It's just extra space.
-remove a br present right before the end of a p.

EDIT: the feature code has regex chaining now.