### PR TITLE
Update swiping offset to be less aggressive

### DIFF
--- a/src/screens/browse/components/BrowseTabs.tsx
+++ b/src/screens/browse/components/BrowseTabs.tsx
@@ -83,8 +83,8 @@ export const InstalledTab = memo(
       ({ item }) => {
         return (
           <Swipeable
-            dragOffsetFromLeftEdge={62}
-            dragOffsetFromRightEdge={62}
+            dragOffsetFromLeftEdge={30}
+            dragOffsetFromRightEdge={30}
             renderLeftActions={(progress, dragX, ref) => {
               return (
                 <View

--- a/src/screens/browse/components/BrowseTabs.tsx
+++ b/src/screens/browse/components/BrowseTabs.tsx
@@ -80,6 +80,8 @@ export const InstalledTab = memo(
       ({ item }) => {
         return (
           <Swipeable
+            dragOffsetFromLeftEdge={62}
+            dragOffsetFromRightEdge={62}
             renderLeftActions={(progress, dragX, ref) => {
               return (
                 <View


### PR DESCRIPTION
Feedback from other users seems to be that the swiping offset is too aggressive, making swiping left and right too janky.
Lowered the value from 62 to 30, triggering the swipe would be happen more frequently when scrolling, but swiping left and right would be much smoother.