### PR TITLE
Re-disable user-select on next-button and info-text

### DIFF
--- a/android/app/src/main/assets/css/index.css
+++ b/android/app/src/main/assets/css/index.css
@@ -96,6 +96,7 @@ td {
   font-family: var(--readerSettings-fontFamily);
   font-size: 16px;
   border-width: 0;
+  user-select: none;
 }
 
 .next-button {


### PR DESCRIPTION
After VanJS commit it was disabled by mistake.