### PR TITLE
fix 'cant parse page' sql syntax error

### DIFF
--- a/src/database/queries/ChapterQueries.ts
+++ b/src/database/queries/ChapterQueries.ts
@@ -42,7 +42,7 @@ export const insertChapters = async (
               `
                 UPDATE Chapter SET
                   page = ?, position = ?
-                WHERE path = ? AND novelId = ? (AND page != ? OR position != ?)
+                WHERE path = ? AND novelId = ? AND (page != ? OR position != ?)
               `,
               [
                 chapter.page || '1',


### PR DESCRIPTION
had issue on novelupdates where opening novels for the first time will give cant parse page error since sql has wrong syntax