### PR TITLE
Allow user input for plugins configurations

### DIFF
--- a/src/hooks/persisted/usePlugins.ts
+++ b/src/hooks/persisted/usePlugins.ts
@@ -108,6 +108,7 @@ export default function usePlugins() {
         const actualPlugin: PluginItem = {
           ...plugin,
           version: _plg.version,
+          hasSettings: !!_plg.pluginSettings,
         };
         // safe
         if (!installedPlugins.some(plg => plg.id === plugin.id)) {

--- a/src/plugins/types/index.ts
+++ b/src/plugins/types/index.ts
@@ -56,6 +56,7 @@ export interface PluginItem {
   customJS?: string;
   customCSS?: string;
   hasUpdate?: boolean;
+  hasSettings?: boolean;
 }
 
 export interface ImageRequestInit {
@@ -68,6 +69,7 @@ export interface ImageRequestInit {
 export interface Plugin extends PluginItem {
   imageRequestInit?: ImageRequestInit;
   filters?: Filters;
+  pluginSettings: any;
   popularNovels: (
     pageNo: number,
     options?: PopularNovelsOptions<Filters>,

--- a/src/screens/browse/components/BrowseTabs.tsx
+++ b/src/screens/browse/components/BrowseTabs.tsx
@@ -31,6 +31,7 @@ import Animated, {
 import { Portal } from 'react-native-paper';
 import SourceSettingsModal from './Modals/SourceSettings';
 import { useBoolean } from '@hooks';
+import { getPlugin } from '@plugins/pluginManager';
 
 interface AvailableTabProps {
   searchText: string;
@@ -55,6 +56,8 @@ export const InstalledTab = memo(
     const { showMyAnimeList, showAniList } = useBrowseSettings();
     const settingsModal = useBoolean();
     const [selectedPluginId, setSelectedPluginId] = useState<string>('');
+
+    const pluginSettings = getPlugin(selectedPluginId)?.pluginSettings;
 
     const navigateToSource = useCallback(
       (plugin: PluginItem, showLatestNovels?: boolean) => {
@@ -165,16 +168,18 @@ export const InstalledTab = memo(
                 </View>
               </View>
               <View style={{ flex: 1 }} />
-              <IconButtonV2
-                name="cog-outline"
-                size={22}
-                color={theme.primary}
-                onPress={() => {
-                  setSelectedPluginId(item.id);
-                  settingsModal.setTrue();
-                }}
-                theme={theme}
-              />
+              {item.hasSettings ? (
+                <IconButtonV2
+                  name="cog-outline"
+                  size={22}
+                  color={theme.primary}
+                  onPress={() => {
+                    setSelectedPluginId(item.id);
+                    settingsModal.setTrue();
+                  }}
+                  theme={theme}
+                />
+              ) : null}
               {item.hasUpdate || __DEV__ ? (
                 <IconButtonV2
                   name="download-outline"
@@ -265,10 +270,8 @@ export const InstalledTab = memo(
                 onDismiss={settingsModal.setFalse}
                 title={getString('browseScreen.settings.title')}
                 description={getString('browseScreen.settings.description')}
-                placeholder={`${getString(
-                  'browseScreen.settings.placeholder',
-                )}`}
                 pluginId={selectedPluginId}
+                pluginSettings={pluginSettings}
               />
             </Portal>
           </>

--- a/src/screens/browse/components/BrowseTabs.tsx
+++ b/src/screens/browse/components/BrowseTabs.tsx
@@ -28,6 +28,9 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { Portal } from 'react-native-paper';
+import SourceSettingsModal from './Modals/SourceSettings';
+import { useBoolean } from '@hooks';
 
 interface AvailableTabProps {
   searchText: string;
@@ -50,6 +53,9 @@ export const InstalledTab = memo(
       updatePlugin,
     } = usePlugins();
     const { showMyAnimeList, showAniList } = useBrowseSettings();
+    const settingsModal = useBoolean();
+    const [selectedPluginId, setSelectedPluginId] = useState<string>('');
+
     const navigateToSource = useCallback(
       (plugin: PluginItem, showLatestNovels?: boolean) => {
         navigation.navigate('SourceScreen', {
@@ -159,6 +165,16 @@ export const InstalledTab = memo(
                 </View>
               </View>
               <View style={{ flex: 1 }} />
+              <IconButtonV2
+                name="cog-outline"
+                size={22}
+                color={theme.primary}
+                onPress={() => {
+                  setSelectedPluginId(item.id);
+                  settingsModal.setTrue();
+                }}
+                theme={theme}
+              />
               {item.hasUpdate || __DEV__ ? (
                 <IconButtonV2
                   name="download-outline"
@@ -242,6 +258,19 @@ export const InstalledTab = memo(
             >
               {getString('browseScreen.installedPlugins')}
             </Text>
+
+            <Portal>
+              <SourceSettingsModal
+                visible={settingsModal.value}
+                onDismiss={settingsModal.setFalse}
+                title={getString('browseScreen.settings.title')}
+                description={getString('browseScreen.settings.description')}
+                placeholder={`${getString(
+                  'browseScreen.settings.placeholder',
+                )}`}
+                pluginId={selectedPluginId}
+              />
+            </Portal>
           </>
         }
       />

--- a/src/screens/browse/components/Modals/SourceSettings.tsx
+++ b/src/screens/browse/components/Modals/SourceSettings.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Modal, overlay, TextInput } from 'react-native-paper';
+import { Button } from '@components/index';
+import { useTheme } from '@hooks/persisted';
+import { getString } from '@strings/translations';
+import { Storage } from '@plugins/helpers/storage';
+
+interface SourceSettingsModal {
+  visible: boolean;
+  onDismiss: () => void;
+  title: string;
+  placeholder?: string;
+  description?: string;
+  pluginId: string;
+}
+
+const SourceSettingsModal: React.FC<SourceSettingsModal> = ({
+  onDismiss,
+  visible,
+  title,
+  placeholder,
+  description,
+  pluginId,
+}) => {
+  const theme = useTheme();
+  const [text, setText] = useState('');
+
+  return (
+    <Modal
+      visible={visible}
+      onDismiss={onDismiss}
+      contentContainerStyle={[
+        styles.modalContainer,
+        { backgroundColor: overlay(2, theme.surface) },
+      ]}
+    >
+      <Text style={[styles.modalTitle, { color: theme.onSurface }]}>
+        {title}
+      </Text>
+      <Text style={[{ color: theme.onSurfaceVariant }]}>{description}</Text>
+      <TextInput
+        multiline
+        mode="outlined"
+        onChangeText={setText}
+        placeholder={placeholder}
+        placeholderTextColor={theme.onSurfaceDisabled}
+        underlineColor={theme.outline}
+        style={[{ color: theme.onSurface }, styles.textInput]}
+        theme={{ colors: { ...theme } }}
+      />
+      <View style={styles.customCSSButtons}>
+        <Button
+          onPress={() => {
+            const settings = text
+              .trim()
+              .split(';')
+              .map(settingString => {
+                const settingArray = settingString.split('=');
+
+                return {
+                  key: settingArray[0],
+                  value: settingArray[1],
+                };
+              });
+            const storage = new Storage(pluginId);
+            settings.forEach(set => storage.set(set.key, set.value));
+            onDismiss();
+          }}
+          style={styles.button}
+          title={getString('common.save')}
+          mode="contained"
+        />
+      </View>
+    </Modal>
+  );
+};
+
+export default SourceSettingsModal;
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    margin: 30,
+    padding: 24,
+    borderRadius: 28,
+  },
+  textInput: {
+    height: 220,
+    borderRadius: 14,
+    marginTop: 16,
+    marginBottom: 8,
+    fontSize: 16,
+  },
+  modalTitle: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+  customCSSButtons: {
+    flexDirection: 'row',
+  },
+  button: {
+    marginTop: 16,
+    flex: 1,
+    marginHorizontal: 8,
+  },
+});

--- a/strings/languages/en/strings.json
+++ b/strings/languages/en/strings.json
@@ -139,7 +139,12 @@
     "tryAgain": "Try again in a moment",
     "uninstalledPlugin": "Uninstalled %{name}",
     "updateFailed": "Update failed",
-    "updatedTo": "Updated to %{version}"
+    "updatedTo": "Updated to %{version}",
+    "settings": {
+      "title": "Plugin Settings",
+      "description": "Add settings in format '<key>=<value>' separated by ';'. Restart app to apply the settings.",
+      "placeholder": "Example: 'email=example@example.com;password=example123'"
+    }
   },
   "browseSettings": "Browse Settings",
   "browseSettingsScreen": {

--- a/strings/languages/en/strings.json
+++ b/strings/languages/en/strings.json
@@ -142,8 +142,7 @@
     "updatedTo": "Updated to %{version}",
     "settings": {
       "title": "Plugin Settings",
-      "description": "Add settings in format '<key>=<value>' separated by ';'. Restart app to apply the settings.",
-      "placeholder": "Example: 'email=example@example.com;password=example123'"
+      "description": "Fill in the plugin settings. Restart app to apply the settings."
     }
   },
   "browseSettings": "Browse Settings",


### PR DESCRIPTION
Adds settings to plugins. issue: #1264 
It allows the user to configure the plugins. For example the plugin I'm working on for komga.
The plugin defines the settings in the following format:
`
pluginSettings = {
    email: {
      value: "",
      label: "Email"
    },
    password: {
      value: "",
      label: "Password"
    },
    url: {
      value: "",
      label: "URL"
    }
  }
`
And the app then adds a cog in the installed plugin like this:
![image](https://github.com/user-attachments/assets/5cb0d12b-abc9-432f-898b-6a2ea04c9243)

When pressed a modal opens up with the inputs defined in the plugin:
![image](https://github.com/user-attachments/assets/8e14b3a1-ec4b-4c68-9a4b-f6af671b2c12)

The setting are stored in the plugin storage. An can be accessed by the plugins.

Corrently it only allows text inputs. Maybe in the future other types could be added. 

Everything seems to be working but I'm sure there will be problems with this as I'm not very familiar with react. Just point them out, maybe answer a few dumb questions from me that might arise and I'll try to fix them.