### PR TITLE
Fix cover height incorrect when screen width changes

### DIFF
--- a/src/components/NovelCover.tsx
+++ b/src/components/NovelCover.tsx
@@ -86,8 +86,7 @@ function NovelCover<TNovel extends CoverItemLibrary | CoverItemPlugin>({
 
   const coverHeight = useMemo(
     () => (window.width / numColumns) * (4 / 3),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [numColumns],
+    [window.width, numColumns],
   );
 
   const selectNovel = () => onLongPress(item);


### PR DESCRIPTION
Fixes covers showing like this in the case screen width changes 
![image](https://github.com/user-attachments/assets/75f526ca-74f2-4537-a14d-239a00ea515d)


https://youtu.be/Sc3Jl0aRXlg