### PR TITLE
fix: "Add tag" input does not work correctly

### DIFF
--- a/src/screens/novel/components/EditInfoModal.tsx
+++ b/src/screens/novel/components/EditInfoModal.tsx
@@ -173,6 +173,10 @@ const EditInfoModal = ({
           onSubmitEditing={() => {
             const newGenreTrimmed = newGenre.trim();
 
+            if (newGenreTrimmed === '') {
+              return;
+            }
+
             setNovelInfo(prevVal => ({
               ...prevVal,
               genres: novelInfo.genres

--- a/src/screens/novel/components/EditInfoModal.tsx
+++ b/src/screens/novel/components/EditInfoModal.tsx
@@ -171,11 +171,13 @@ const EditInfoModal = ({
           mode="outlined"
           onChangeText={text => setNewGenre(text)}
           onSubmitEditing={() => {
+            const newGenreTrimmed = newGenre.trim();
+
             setNovelInfo(prevVal => ({
               ...prevVal,
               genres: novelInfo.genres
-                ? `${novelInfo.genres},`
-                : '' + newGenre.trim(),
+                ? `${novelInfo.genres},` + newGenreTrimmed
+                : newGenreTrimmed,
             }));
             setNewGenre('');
           }}


### PR DESCRIPTION
Closes #1356 

| v2.0.0-beta.3 | this pr |
| - | - |
| ![Image 2024-12-16](https://github.com/user-attachments/assets/91811b70-21ee-4119-a155-987bbac03ebf) | ![Image 2024-12-16](https://github.com/user-attachments/assets/6a0daa20-7f2f-4006-8b0d-361aacbc7c17) |

**Note:** Also fixed a small bug where empty tags could be added when the novel already had at least one valid tag, similar to what happens in the first image.