### PR TITLE
CREATE BACKUP FILE NOT WORKING, FIXED

### DIFF
--- a/src/services/backup/legacy/index.ts
+++ b/src/services/backup/legacy/index.ts
@@ -21,7 +21,7 @@ export const createBackup = async () => {
     if (!folder) {
       return;
     }
-    const datetime = dayjs().format('YYYY-MM-DD_HH:mm');
+    const datetime = dayjs().format('YYYY-MM-DD_HH_mm');
     const fileName = 'lnreader_backup_' + datetime + '.json';
     await FileManager.writeFile(
       folder + '/' + fileName,


### PR DESCRIPTION
in android file system you can't use the char  ' : '  so lnreader file name:
"Inreader_backup_YYYY-MM-DD_HH:mm.json"
you can't write it as a file. 
so i edit it to looks like
"Inreader_backup_YYYY-MM-DD_HH_mm.json"