### PR TITLE
Fixed last read not updating and bookmark button in reader mode.

### DIFF
--- a/src/screens/reader/ReaderScreen.tsx
+++ b/src/screens/reader/ReaderScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useState } from 'react';
 import { DrawerLayoutAndroid } from 'react-native';
 
 import { useChapterGeneralSettings, useTheme } from '@hooks/persisted';
@@ -63,6 +63,7 @@ export const ChapterContent = ({
   const readerSheetRef = useRef<BottomSheetModalMethods>(null);
   const theme = useTheme();
   const { pageReader = false, keepScreenOn } = useChapterGeneralSettings();
+  const [bookmarked, setBookmarked] = useState(chapter.bookmark);
 
   const {
     hidden,
@@ -146,7 +147,12 @@ export const ChapterContent = ({
       <ReaderBottomSheetV2 bottomSheetRef={readerSheetRef} />
       {!hidden ? (
         <>
-          <ReaderAppbar goBack={navigation.goBack} theme={theme} />
+          <ReaderAppbar
+            goBack={navigation.goBack}
+            theme={theme}
+            bookmarked={bookmarked}
+            setBookmarked={setBookmarked}
+          />
           <ReaderFooter
             theme={theme}
             nextChapter={nextChapter}

--- a/src/screens/reader/ReaderScreen.tsx
+++ b/src/screens/reader/ReaderScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useState } from 'react';
+import React, { useRef, useCallback, useState, useEffect } from 'react';
 import { DrawerLayoutAndroid } from 'react-native';
 
 import { useChapterGeneralSettings, useTheme } from '@hooks/persisted';
@@ -64,6 +64,10 @@ export const ChapterContent = ({
   const theme = useTheme();
   const { pageReader = false, keepScreenOn } = useChapterGeneralSettings();
   const [bookmarked, setBookmarked] = useState(chapter.bookmark);
+
+  useEffect(() => {
+    setBookmarked(chapter.bookmark);
+  }, [chapter]);
 
   const {
     hidden,

--- a/src/screens/reader/components/ReaderAppbar.tsx
+++ b/src/screens/reader/components/ReaderAppbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { StatusBar, StyleSheet, View } from 'react-native';
 import color from 'color';
 
@@ -14,12 +14,18 @@ interface ReaderAppbarProps {
   goBack: () => void;
 }
 
-const ReaderAppbar = ({ goBack, theme }: ReaderAppbarProps) => {
+const ReaderAppbar = ({
+  goBack,
+  theme,
+  bookmarked,
+  setBookmarked,
+}: ReaderAppbarProps) => {
   const { chapter, novel } = useChapterContext();
-  const [bookmarked, setBookmarked] = useState(chapter.bookmark);
+
   useEffect(() => {
     setBookmarked(chapter.bookmark);
   }, [chapter]);
+
   return (
     <Animated.View
       entering={FadeIn.duration(150)}

--- a/src/screens/reader/components/ReaderAppbar.tsx
+++ b/src/screens/reader/components/ReaderAppbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { StatusBar, StyleSheet, View } from 'react-native';
 import color from 'color';
 
@@ -21,10 +21,6 @@ const ReaderAppbar = ({
   setBookmarked,
 }: ReaderAppbarProps) => {
   const { chapter, novel } = useChapterContext();
-
-  useEffect(() => {
-    setBookmarked(chapter.bookmark);
-  }, [chapter]);
 
   return (
     <Animated.View

--- a/src/screens/reader/hooks/useChapter.ts
+++ b/src/screens/reader/hooks/useChapter.ts
@@ -189,22 +189,18 @@ export default function useChapter(webViewRef: RefObject<WebView>) {
   useEffect(() => {
     setLoading(true);
     getChapter().finally(() => setLoading(false));
+
     if (!incognitoMode) {
       insertHistory(chapter.id);
-      setLastRead(chapter);
-    }
-  }, [chapter]);
-
-  useEffect(() => {
-    if (!incognitoMode) {
       getDbChapter(chapter.id).then(result => setLastRead(result));
     }
+
     return () => {
       if (!incognitoMode) {
         getDbChapter(chapter.id).then(result => setLastRead(result));
       }
     };
-  }, []);
+  }, [chapter]);
 
   const refetch = () => {
     setLoading(true);

--- a/src/screens/reader/hooks/useChapter.ts
+++ b/src/screens/reader/hooks/useChapter.ts
@@ -1,4 +1,5 @@
 import {
+  getChapter as getDbChapter,
   getNextChapter,
   getPrevChapter,
   markChapterRead,
@@ -193,6 +194,17 @@ export default function useChapter(webViewRef: RefObject<WebView>) {
       setLastRead(chapter);
     }
   }, [chapter]);
+
+  useEffect(() => {
+    if (!incognitoMode) {
+      getDbChapter(chapter.id).then(result => setLastRead(result));
+    }
+    return () => {
+      if (!incognitoMode) {
+        getDbChapter(chapter.id).then(result => setLastRead(result));
+      }
+    };
+  }, []);
 
   const refetch = () => {
     setLoading(true);


### PR DESCRIPTION
Previously, the bookmark button in the reader top bar would always reset to whatever the status was when you first opened the chapter. Additionally, if you read part of a chapter or bookmarked a chapter, left reader mode, then pressed the "continue reading" button to get back to where you left off, the bookmark status and reading progress would not have been saved like if you opened the chapter via the list.

I tried to make the least intrusive changes I could, since the core problem with the "continue reading" bug is that state variables are not updated, and instead changes are directly saved to the database in other sections. The best solution would require rewriting a good section of the codebase.

If changes are necessary, please let me know.