### PR TITLE
fix: fix alignment of save novel cover button

### DIFF
--- a/src/screens/novel/components/Info/NovelInfoComponents.tsx
+++ b/src/screens/novel/components/Info/NovelInfoComponents.tsx
@@ -6,7 +6,6 @@ import {
   View,
   Pressable,
   ImageBackground,
-  StatusBar,
 } from 'react-native';
 import color from 'color';
 import { IconButton, Portal } from 'react-native-paper';
@@ -110,8 +109,8 @@ const NovelThumbnail = ({
             icon="pencil-outline"
             style={{
               position: 'absolute',
-              top: StatusBar.currentHeight ?? 0 + 10,
-              right: 60,
+              top: top + 6,
+              right: right + 60,
               zIndex: 10,
             }}
             iconColor={theme.onBackground}


### PR DESCRIPTION
Save and edit buttons for novel cover image were misaligned while resolving conflicts

Before:
<img src="https://github.com/user-attachments/assets/672acf3c-9d7e-4de1-9320-699d52fbc8e2" width="300"/>

After:
<img src="https://github.com/user-attachments/assets/92c2e070-800d-43ac-b8b8-ff0975f38ba4" width="300"/>
