### PR TITLE
Allow "style" attribute in the sanitizer for  span

### DIFF
--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -26,7 +26,7 @@ export const sanitizeChapterText = (
       div: ['class', 'id'],
       img: ['src', 'class', 'id'],
       ol: ['reversed', 'start', 'type'],
-      p: ['class', 'id', 'style'],
+      p: ['class', 'id'],
       span: ['class', 'id', 'style'],
     },
     allowedSchemes: ['data', 'http', 'https', 'file'],

--- a/src/screens/reader/utils/sanitizeChapterText.ts
+++ b/src/screens/reader/utils/sanitizeChapterText.ts
@@ -26,8 +26,8 @@ export const sanitizeChapterText = (
       div: ['class', 'id'],
       img: ['src', 'class', 'id'],
       ol: ['reversed', 'start', 'type'],
-      p: ['class', 'id'],
-      span: ['class', 'id'],
+      p: ['class', 'id', 'style'],
+      span: ['class', 'id', 'style'],
     },
     allowedSchemes: ['data', 'http', 'https', 'file'],
   });


### PR DESCRIPTION
idk what is the use of a span without style.

The vast majority of times they just end up like fish faces ``<span>`` with no attribute due to the sanitizer not allowing styles for them. 

It's useful when reading imported epubs