### PR TITLE
chore(build): patch @rock-js/plugin-metro for Windows compatibility

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,10 +23,11 @@ plugins {
 }
 
 extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
+  def npxCmd = System.getProperty('os.name').toLowerCase().contains('windows') ? 'npx.cmd' : 'npx'
   if (System.getenv('EXPO_USE_COMMUNITY_AUTOLINKING') == '1') {
-    ex.autolinkLibrariesFromCommand(['npx', 'rock', 'config', '-p', 'android'])
+    ex.autolinkLibrariesFromCommand([npxCmd, 'rock', 'config', '-p', 'android'])
   } else {
-    ex.autolinkLibrariesFromCommand(['npx', 'rock', 'config', '-p', 'android'])
+    ex.autolinkLibrariesFromCommand([npxCmd, 'rock', 'config', '-p', 'android'])
   }
 }
 

--- a/patches/@rock-js__plugin-metro@0.12.12.patch
+++ b/patches/@rock-js__plugin-metro@0.12.12.patch
@@ -1,0 +1,23 @@
+diff --git a/dist/src/lib/getReactNativeDeps.js b/dist/src/lib/getReactNativeDeps.js
+index d523e094eb456f91ee8c4de0f65500e4ec002991..1aa6f27ca1cef322db66d2f47a7cbd8a980dcbc2 100644
+--- a/dist/src/lib/getReactNativeDeps.js
++++ b/dist/src/lib/getReactNativeDeps.js
+@@ -1,15 +1,16 @@
+ import { createRequire } from 'node:module';
++import { pathToFileURL } from 'node:url';
+ export async function getDevMiddleware(reactNativePath) {
+     const require = createRequire(import.meta.url);
+     const reactNativeCommunityCliPluginPath = require.resolve('@react-native/community-cli-plugin', { paths: [reactNativePath] });
+     const devMiddlewarePath = require.resolve('@react-native/dev-middleware', {
+         paths: [reactNativeCommunityCliPluginPath],
+     });
+-    return import(devMiddlewarePath);
++    return import(pathToFileURL(devMiddlewarePath).href);
+ }
+ export async function getReactNativeCommunityCliPlugin(reactNativePath) {
+     const require = createRequire(import.meta.url);
+     const reactNativeCommunityCliPluginPath = require.resolve('@react-native/community-cli-plugin', { paths: [reactNativePath] });
+-    return import(reactNativeCommunityCliPluginPath);
++    return import(pathToFileURL(reactNativeCommunityCliPluginPath).href);
+ }
+ //# sourceMappingURL=getReactNativeDeps.js.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@rock-js/plugin-metro@0.12.12':
+    hash: fb21d963fa0452524ca33673321a4a405c81e09817a628b64e4c72eee6c39747
+    path: patches/@rock-js__plugin-metro@0.12.12.patch
+
 importers:
 
   .:
@@ -254,7 +259,7 @@ importers:
         version: 0.12.12(typescript@5.9.3)
       '@rock-js/plugin-metro':
         specifier: ^0.12.12
-        version: 0.12.12
+        version: 0.12.12(patch_hash=fb21d963fa0452524ca33673321a4a405c81e09817a628b64e4c72eee6c39747)
       '@rock-js/provider-github':
         specifier: ^0.12.12
         version: 0.12.12
@@ -2140,6 +2145,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -6088,10 +6094,12 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -8562,7 +8570,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@rock-js/plugin-metro@0.12.12':
+  '@rock-js/plugin-metro@0.12.12(patch_hash=fb21d963fa0452524ca33673321a4a405c81e09817a628b64e4c72eee6c39747)':
     dependencies:
       '@react-native-community/cli-server-api': 20.1.3
       '@rock-js/tools': 0.12.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,9 @@
+nodeLinker: hoisted
+
 onlyBuiltDependencies:
   - better-sqlite3
   - esbuild
   - protobufjs
+
+patchedDependencies:
+  '@rock-js/plugin-metro@0.12.12': patches/@rock-js__plugin-metro@0.12.12.patch


### PR DESCRIPTION
## Summary

Make the Android dev build work on Windows hosts by patching `@rock-js/plugin-metro` and the autolink invocation in `android/settings.gradle`.

## Why

On Windows, two things break the current setup:

1. `@rock-js/plugin-metro@0.12.12` does a dynamic `import(absolutePath)`. Node on Windows requires `file://` URLs for absolute paths, otherwise it throws `ERR_UNSUPPORTED_ESM_URL_SCHEME`. The patch wraps the path with `pathToFileURL()`.
2. `android/settings.gradle` shells out to `npx`. On Windows the executable is `npx.cmd`; the bare `npx` fails with "Cannot run program 'npx'". Switch to `npx.cmd` when `os.name` is Windows.

## What's in the PR

- `patches/@rock-js__plugin-metro@0.12.12.patch` — pnpm patch that wraps absolute paths in `pathToFileURL()`.
- `pnpm-workspace.yaml` — register the patch and pin `nodeLinker: hoisted`.
- `pnpm-lock.yaml` — locked patched version.
- `android/settings.gradle` — invoke `npx.cmd` on Windows; behaviour on macOS/Linux is unchanged (still calls `npx`).

## Test plan

- [ ] Windows: `pnpm install && pnpm android` builds and launches without manual intervention.
- [ ] macOS / Linux: `pnpm install && pnpm android` still works (autolink path goes through the existing `npx` branch).

## Notes

I'm aware this is a Windows-specific quality-of-life patch. If you'd rather upstream the dynamic-import fix to `@rock-js/plugin-metro` directly and skip the local patch, I'm happy to redirect there — just let me know.