### PR TITLE
fix(native-file): prevent fatal crash when unlinking missing files

### DIFF
--- a/android/app/src/main/java/com/rajarsheechatterjee/NativeFile/NativeFile.kt
+++ b/android/app/src/main/java/com/rajarsheechatterjee/NativeFile/NativeFile.kt
@@ -150,7 +150,7 @@ class NativeFile(context: ReactApplicationContext) :
 
     override fun unlink(filepath: String) {
         val file = File(filepath)
-        if (!file.exists()) throw Exception("File does not exist")
+        if (!file.exists()) return
         deleteRecursive(file)
     }
 


### PR DESCRIPTION
## Summary

Make `NativeFile.unlink` idempotent so a missing path is a no-op instead of a fatal crash. POSIX `rm -f` semantics.

One-line change:

```kotlin
// before
override fun unlink(filepath: String) {
    val file = File(filepath)
    if (!file.exists()) throw Exception(\"File does not exist\")
    deleteRecursive(file)
}

// after
override fun unlink(filepath: String) {
    val file = File(filepath)
    if (!file.exists()) return
    deleteRecursive(file)
}
```

## Why this is a real crash, not a swallowed error

`NativeFileSpec.unlink` is codegened as a **void-returning TurboModule** method, which means it dispatches asynchronously on the `mqt_v_native` thread. When it throws, the exception is **not** thrown back into the JS frame — it surfaces as an unhandled `AndroidRuntime` exception and Android tears down the process.

Stack trace I captured by reproducing on a Galaxy S23:

```
FATAL EXCEPTION: mqt_v_native
Process: com.rajarsheechatterjee.LNReader, PID: <pid>
java.lang.Exception: File does not exist
    at com.rajarsheechatterjee.NativeFile.NativeFile.unlink(NativeFile.kt:153)
    at com.facebook.jni.NativeRunnable.run(Native Method)
    at android.os.Handler.handleCallback(Handler.java:995)
    ...
```

The JS-side `try/catch` in `deleteDownloadedFiles` is harmless here — it never sees the exception because the throw happens on a different thread *after* the JS call has returned.

## Repro

1. Have a downloaded chapter where the on-disk folder has been deleted out of band (after a backup restore, after manually clearing app cache, after the app was force-killed mid-write, etc.) but the DB row still has `isDownloaded = true`.
2. More → Downloads → tap the bulk delete (sweep) icon → Ok. Or pick any individual chapter and delete.
3. App force-closes immediately.

## Why it's safe to make `unlink` idempotent

- The function's contract per the spec JSDoc is \"remove recursively\". Returning successfully when the target doesn't exist matches the user's intent — the file is gone, that's the goal.
- Eight call sites benefit (`ChapterQueries`, `useNovel`, `pluginManager`, `helpers/fetch`, `epub/import`, `backup/local`, `backup/utils`, `AdvancedTab.tsx`). None of them treat \"file already absent\" as an error condition; they all wrap the call in `try/catch` for unrelated I/O failures.
- No JS-side change is needed and there's no behavioural difference for callers whose target exists.

## Test plan

- [x] Reproduce crash on Galaxy S23 (Android 14) with a stale `isDownloaded=true` row.
- [x] Apply the fix, rebuild, reinstall.
- [x] Bulk delete now transitions to \"No downloads\" empty state with no AndroidRuntime errors in `logcat`.
- [ ] Individual chapter delete with stale row.
- [ ] Backup restore followed immediately by Downloads bulk delete.