### PR TITLE
fix(reader): restore saved chapter progress from db if available

### DIFF
--- a/src/screens/reader/hooks/__tests__/useChapter.test.ts
+++ b/src/screens/reader/hooks/__tests__/useChapter.test.ts
@@ -196,6 +196,37 @@ describe('useChapter', () => {
     );
   });
 
+  it('hydrates the initial chapter from the database before rendering reader progress', async () => {
+    const store = createStore({ [initialChapter.id]: 'cached chapter body' });
+    const hydratedChapter = { ...initialChapter, progress: 56 };
+    mockUseNovelActions.mockReturnValue(store.state);
+    mockGetDbChapter.mockResolvedValue(hydratedChapter);
+
+    const { result } = renderHook(() =>
+      useChapter({ current: null }, initialChapter, novel),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.chapter.progress).toBe(56);
+  });
+
+  it('uses database progress as the source of truth on initial open', async () => {
+    const routeChapter = { ...initialChapter, progress: 72 };
+    const dbChapter = { ...initialChapter, progress: 12 };
+    const store = createStore({ [initialChapter.id]: 'cached chapter body' });
+    mockUseNovelActions.mockReturnValue(store.state);
+    mockGetDbChapter.mockResolvedValue(dbChapter);
+
+    const { result } = renderHook(() =>
+      useChapter({ current: null }, routeChapter, novel),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.chapter.progress).toBe(12);
+  });
+
   it('updates chapter progress, caps at 100, and marks chapter read/tracker progress near completion', async () => {
     const store = createStore();
     const updateAllTrackedNovels = jest.fn();

--- a/src/screens/reader/hooks/useChapter.ts
+++ b/src/screens/reader/hooks/useChapter.ts
@@ -125,7 +125,10 @@ export default function useChapter(
   const getChapter = useCallback(
     async (navChapter?: ChapterInfo) => {
       try {
-        const chap = navChapter ?? chapter;
+        const dbChapter = navChapter
+          ? undefined
+          : await getDbChapter(chapter.id);
+        const chap = dbChapter ?? navChapter ?? chapter;
         const cachedText = chapterTextCache.read(chap.id);
         const text = cachedText ?? loadChapterText(chap.id, chap.path);
         const [nextChapResult, prevChapResult, awaitedText] = await Promise.all(


### PR DESCRIPTION
Fixes #1468
Issue:
Reopening a partially read chapter could start from the beginning instead of restoring the saved progress. The reader WebView receives its initial progress from the chapter object passed through navigation, but that object can be stale and still contain `progress: 0` even after the latest progress has been persisted.

Change:
Hydrates the initial reader chapter from the database before rendering, so reopening a partially read chapter restores saved progress instead of starting at 0%.

Manual testing:
- Opened a chapter, read until partway through, returned to the chapter list, reopened the chapter, and confirmed it resumed at the saved position.
- Opened a chapter, read until partway through, scrolled farther down, scrolled back up, returned, reopened the chapter, and confirmed it resumed at the most recently saved position.
- Opened a chapter, read until partway through, closed the app, reopened it, opened the same chapter, and confirmed it resumed at the saved position.

Other checks:
- Built release APK locally.
- Ran ESLint on changed files.
- Ran Prettier check on changed files.