### PR TITLE
fix(tts): remove leading and trailing quotes from normalized text

### DIFF
--- a/android/app/src/main/assets/js/core.js
+++ b/android/app/src/main/assets/js/core.js
@@ -167,6 +167,7 @@ window.tts = new (function () {
   this.normalizeText = text => {
     if (!text) return '';
     return text
+      .replace(/^["'“”‘’]+|["'“”‘’]+$/g, '')
       .replace(/\s+/g, ' ')
       .replace(/\s*([.,!?;:])\s*/g, '$1 ')
       .trim();


### PR DESCRIPTION
When text containing trailing quotation marks (such as `"`) is sent to the TTS engine, the engine explicitly speaks the word "quote" rather than ignoring the punctuation. This PR adds a regex normalization step to strip leading and trailing quotes from the text before it is processed by the TTS engine.

#### **Changes**

- Added regular expression logic to strip leading and trailing straight/curly quotes from the text string.
- Handled edge cases where dangling quotes at the end of sentences caused unexpected spoken artifacts.

#### **Testing Instructions**

1. Pass a text string ending in a quotation mark (e.g., `Hello World"`) to the TTS feature.
2. Verify that the engine no longer vocalizes the word "quote" at the beginning or end of the text segment.