### PR TITLE
feat: implement time-tracking and statistics

### DIFF
--- a/drizzle/20260719143427_long_moondragon/migration.sql
+++ b/drizzle/20260719143427_long_moondragon/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Chapter` ADD `timeSpent` integer DEFAULT 0;

--- a/drizzle/20260719143427_long_moondragon/snapshot.json
+++ b/drizzle/20260719143427_long_moondragon/snapshot.json
@@ -1,0 +1,644 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "498c0b85-a3f4-413f-8fed-7914c3ba15d9",
+  "prevIds": [
+    "51b6018f-2f9b-49d9-9762-37522abbdbf1"
+  ],
+  "ddl": [
+    {
+      "name": "Category",
+      "entityType": "tables"
+    },
+    {
+      "name": "Chapter",
+      "entityType": "tables"
+    },
+    {
+      "name": "NovelCategory",
+      "entityType": "tables"
+    },
+    {
+      "name": "Novel",
+      "entityType": "tables"
+    },
+    {
+      "name": "Repository",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "Category"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "Category"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sort",
+      "entityType": "columns",
+      "table": "Category"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "novelId",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "releaseTime",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "bookmark",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "unread",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "readTime",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "isDownloaded",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updatedTime",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chapterNumber",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'1'",
+      "generated": null,
+      "name": "page",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "progress",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scanlator",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "timeSpent",
+      "entityType": "columns",
+      "table": "Chapter"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "NovelCategory"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "novelId",
+      "entityType": "columns",
+      "table": "NovelCategory"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "categoryId",
+      "entityType": "columns",
+      "table": "NovelCategory"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pluginId",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cover",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "author",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "artist",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'Unknown'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "genres",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "inLibrary",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "isLocal",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "totalPages",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "chaptersDownloaded",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "chaptersUnread",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "totalChapters",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lastReadAt",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lastUpdatedAt",
+      "entityType": "columns",
+      "table": "Novel"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "Repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "Repository"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "Category_pk",
+      "table": "Category",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "Chapter_pk",
+      "table": "Chapter",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "NovelCategory_pk",
+      "table": "NovelCategory",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "Novel_pk",
+      "table": "Novel",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "Repository_pk",
+      "table": "Repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "category_name_unique",
+      "entityType": "indexes",
+      "table": "Category"
+    },
+    {
+      "columns": [
+        {
+          "value": "sort",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "category_sort_idx",
+      "entityType": "indexes",
+      "table": "Category"
+    },
+    {
+      "columns": [
+        {
+          "value": "novelId",
+          "isExpression": false
+        },
+        {
+          "value": "path",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "chapter_novel_path_unique",
+      "entityType": "indexes",
+      "table": "Chapter"
+    },
+    {
+      "columns": [
+        {
+          "value": "novelId",
+          "isExpression": false
+        },
+        {
+          "value": "position",
+          "isExpression": false
+        },
+        {
+          "value": "page",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "chapterNovelIdIndex",
+      "entityType": "indexes",
+      "table": "Chapter"
+    },
+    {
+      "columns": [
+        {
+          "value": "novelId",
+          "isExpression": false
+        },
+        {
+          "value": "categoryId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "novel_category_unique",
+      "entityType": "indexes",
+      "table": "NovelCategory"
+    },
+    {
+      "columns": [
+        {
+          "value": "path",
+          "isExpression": false
+        },
+        {
+          "value": "pluginId",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "novel_path_plugin_unique",
+      "entityType": "indexes",
+      "table": "Novel"
+    },
+    {
+      "columns": [
+        {
+          "value": "pluginId",
+          "isExpression": false
+        },
+        {
+          "value": "path",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "inLibrary",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "NovelIndex",
+      "entityType": "indexes",
+      "table": "Novel"
+    },
+    {
+      "columns": [
+        {
+          "value": "url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_url_unique",
+      "entityType": "indexes",
+      "table": "Repository"
+    }
+  ],
+  "renames": []
+}

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -1,9 +1,13 @@
+// This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
+
 import m0000 from './20251222152612_past_mandrill/migration.sql';
 import m0001 from './20260612232322_normal_saracen/migration.sql';
+import m0002 from './20260719143427_long_moondragon/migration.sql';
 
 export default {
   migrations: {
-    '20251222152612_past_mandrill': m0000,
-    '20260612232322_normal_saracen': m0001,
-  },
-};
+    "20251222152612_past_mandrill": m0000,
+    "20260612232322_normal_saracen": m0001,
+    "20260719143427_long_moondragon": m0002
+  }
+}

--- a/src/database/__tests__/db.test.ts
+++ b/src/database/__tests__/db.test.ts
@@ -244,6 +244,7 @@ describe('production migrations', () => {
       expect(appliedMigrations.map(row => row.name)).toEqual([
         '20251222152612_past_mandrill',
         '20260612232322_normal_saracen',
+		'20260719143427_long_moondragon'
       ]);
     } finally {
       sqlite.close();

--- a/src/database/queries/ChapterQueries.ts
+++ b/src/database/queries/ChapterQueries.ts
@@ -227,6 +227,19 @@ export const deleteChapters = async (
   });
 };
 
+/** Increases the timeSpent for the specified chapterId by the given amount */
+export const increaseTimeSpent = async (
+  chapterId: number,
+  timeSpent: number,
+): Promise<void> => {
+  await dbManager.write(async tx => {
+    await tx.update(chapterSchema)
+      .set({ timeSpent: sql`COALESCE(${chapterSchema.timeSpent}, 0) + ${timeSpent}` })
+      .where(eq(chapterSchema.id, chapterId))
+      .run();
+  });
+};
+
 // TODO: Remove the need for the chapters array, as it could lead to not deleting the downloaded files but just marking them as not downloaded
 /*
   Deletes all downloaded chapters from the database

--- a/src/database/queries/StatsQueries.ts
+++ b/src/database/queries/StatsQueries.ts
@@ -2,7 +2,7 @@ import { countBy } from 'lodash-es';
 import { eq, count, and, sql } from 'drizzle-orm';
 import { LibraryStats } from '../types';
 import { dbManager } from '@database/db';
-import { novelSchema, chapterSchema } from '@database/schema';
+import { novelSchema, chapterSchema, categorySchema, novelCategorySchema } from '@database/schema';
 
 /**
  * Get library statistics (novel count and distinct sources) using Drizzle ORM
@@ -33,6 +33,59 @@ export const getChaptersTotalCountFromDb = async (): Promise<LibraryStats> => {
 
   return result ?? { chaptersCount: 0 };
 };
+
+/**
+ * Get top novels based on time spent
+ */
+export const getTopNovelsByTimeSpentFromDb = async (): Promise<LibraryStats> => {
+  const result = await dbManager
+    .select({
+      id: novelSchema.id,
+      pluginId: novelSchema.pluginId,
+      cover: novelSchema.cover,
+      name: novelSchema.name,
+      timeSpent: sql<number>`SUM(${chapterSchema.timeSpent})`,
+    })
+    .from(novelSchema)
+    .innerJoin(chapterSchema, eq(chapterSchema.novelId, novelSchema.id))
+    .where(eq(novelSchema.inLibrary, true))
+    .groupBy(novelSchema.id)
+    .orderBy(sql`SUM(${chapterSchema.timeSpent}) DESC`)
+    .having(sql`SUM(${chapterSchema.timeSpent}) > 0`)
+    .limit(10)
+    .all();
+
+  return { topNovelsByTimeSpent: result };
+};
+
+/** Get top categories based on time spent */
+export const getTopCategoriesByTimeSpentFromDb = async (): Promise<LibraryStats> => {
+  const result = await dbManager
+    .select({
+      id: categorySchema.id,
+      name: categorySchema.name,
+      timeSpent: sql<number>`SUM(${chapterSchema.timeSpent})`
+    })
+    .from(categorySchema)
+    .innerJoin(novelCategorySchema, eq(categorySchema.id, novelCategorySchema.categoryId))
+    .innerJoin(novelSchema, eq(novelSchema.id, novelCategorySchema.novelId))
+    .innerJoin(chapterSchema, eq(novelSchema.id, chapterSchema.novelId))
+    .groupBy(categorySchema.id)
+    .orderBy(sql`SUM(${chapterSchema.timeSpent}) DESC`)
+    .having(sql`SUM(${chapterSchema.timeSpent}) > 0`)
+    .limit(10)
+    .all()
+  return { topCategoriesByTimeSpent: result };
+}
+
+/** Sum up the timeSpent for all chapters */
+export const getTotalTimeSpentFromDb = async (): Promise<LibraryStats> => {
+  const result = await dbManager
+    .select({ totalTimeSpent: sql<number>`COALESCE(SUM(${chapterSchema.timeSpent}), 0)` })
+    .from(chapterSchema)
+    .get();
+  return { totalTimeSpent: result?.totalTimeSpent ?? 0 };
+}
 
 /**
  * Get total read chapters count for all novels in library

--- a/src/database/queries/__tests__/ChapterQueries.test.ts
+++ b/src/database/queries/__tests__/ChapterQueries.test.ts
@@ -46,6 +46,7 @@ import {
   getFirstUnreadChapter,
   getNovelScanlators,
   getNovelScanlatorsSync,
+  increaseTimeSpent,
 } from '../ChapterQueries';
 
 describe('ChapterQueries', () => {
@@ -1399,6 +1400,84 @@ describe('ChapterQueries', () => {
       expect(scanlatorsSync).toHaveLength(2);
       expect(scanlatorsSync).toContain('Scan A');
       expect(scanlatorsSync).toContain('Scan B');
+    });
+  });
+  describe('increaseTimeSpent', () => {
+    it('should increase timeSpent from default 0', async () => {
+      const testDb = getTestDb();
+
+      const novelId = await insertTestNovel(testDb, { inLibrary: true });
+      const chapterId = await insertTestChapter(testDb, novelId, {});
+
+      await increaseTimeSpent(chapterId, 500);
+
+      const chapters = await getNovelChapters(novelId);
+      const chapter = chapters.find(c => c.id === chapterId);
+      expect(chapter?.timeSpent).toBe(500);
+    });
+
+    it('should accumulate timeSpent across multiple calls', async () => {
+      const testDb = getTestDb();
+
+      const novelId = await insertTestNovel(testDb, { inLibrary: true });
+      const chapterId = await insertTestChapter(testDb, novelId, {});
+
+      await increaseTimeSpent(chapterId, 300);
+      await increaseTimeSpent(chapterId, 200);
+
+      const chapters = await getNovelChapters(novelId);
+      const chapter = chapters.find(c => c.id === chapterId);
+      expect(chapter?.timeSpent).toBe(500);
+    });
+
+    it('should add to a pre-existing non-zero timeSpent', async () => {
+      const testDb = getTestDb();
+
+      const novelId = await insertTestNovel(testDb, { inLibrary: true });
+      const chapterId = await insertTestChapter(testDb, novelId, {
+        timeSpent: 1000,
+      });
+
+      await increaseTimeSpent(chapterId, 250);
+
+      const chapters = await getNovelChapters(novelId);
+      const chapter = chapters.find(c => c.id === chapterId);
+      expect(chapter?.timeSpent).toBe(1250);
+    });
+
+    it('should only update the targeted chapter', async () => {
+      const testDb = getTestDb();
+
+      const novelId = await insertTestNovel(testDb, { inLibrary: true });
+      const chapterId1 = await insertTestChapter(testDb, novelId, {});
+      const chapterId2 = await insertTestChapter(testDb, novelId, {});
+
+      await increaseTimeSpent(chapterId1, 400);
+
+      const chapters = await getNovelChapters(novelId);
+      const chapter1 = chapters.find(c => c.id === chapterId1);
+      const chapter2 = chapters.find(c => c.id === chapterId2);
+      expect(chapter1?.timeSpent).toBe(400);
+      expect(chapter2?.timeSpent).toBe(0);
+    });
+
+    it('should be a no-op for a non-existent chapterId', async () => {
+      await expect(increaseTimeSpent(999999, 100)).resolves.not.toThrow();
+    });
+
+    it('should handle a timeSpent value of 0', async () => {
+      const testDb = getTestDb();
+
+      const novelId = await insertTestNovel(testDb, { inLibrary: true });
+      const chapterId = await insertTestChapter(testDb, novelId, {
+        timeSpent: 750,
+      });
+
+      await increaseTimeSpent(chapterId, 0);
+
+      const chapters = await getNovelChapters(novelId);
+      const chapter = chapters.find(c => c.id === chapterId);
+      expect(chapter?.timeSpent).toBe(750);
     });
   });
 });

--- a/src/database/queries/__tests__/StatsQueries.test.ts
+++ b/src/database/queries/__tests__/StatsQueries.test.ts
@@ -6,7 +6,7 @@
 
 import './mockDb';
 import { setupTestDatabase, getTestDb, teardownTestDatabase } from './setup';
-import { insertTestNovel, insertTestChapter, clearAllTables } from './testData';
+import { insertTestNovel, insertTestChapter, clearAllTables, insertTestNovelCategory, insertTestCategory } from './testData';
 
 import {
   getLibraryStatsFromDb,
@@ -16,6 +16,9 @@ import {
   getChaptersDownloadedCountFromDb,
   getNovelGenresFromDb,
   getNovelStatusFromDb,
+  getTotalTimeSpentFromDb,
+  getTopCategoriesByTimeSpentFromDb,
+  getTopNovelsByTimeSpentFromDb,
 } from '../StatsQueries';
 
 describe('StatsQueries', () => {
@@ -321,6 +324,166 @@ describe('StatsQueries', () => {
       const result = await getNovelStatusFromDb();
 
       expect(result.status).toEqual({ Ongoing: 1 });
+    });
+  });
+  describe('getTopNovelsByTimeSpentFromDb', () => {
+    it('should return top novels ordered by total time spent descending', async () => {
+      const testDb = getTestDb();
+
+      const novelId1 = await insertTestNovel(testDb, {
+        name: 'Novel A',
+        inLibrary: true,
+      });
+      await insertTestChapter(testDb, novelId1, { timeSpent: 100 });
+      await insertTestChapter(testDb, novelId1, { timeSpent: 200 });
+
+      const novelId2 = await insertTestNovel(testDb, {
+        name: 'Novel B',
+        inLibrary: true,
+      });
+      await insertTestChapter(testDb, novelId2, { timeSpent: 500 });
+
+      const result = await getTopNovelsByTimeSpentFromDb();
+
+      expect(result.topNovelsByTimeSpent).toHaveLength(2);
+      expect(result.topNovelsByTimeSpent!![0]).toMatchObject({
+        id: novelId2,
+        name: 'Novel B',
+        timeSpent: 500,
+      });
+      expect(result.topNovelsByTimeSpent!![1]).toMatchObject({
+        id: novelId1,
+        name: 'Novel A',
+        timeSpent: 300,
+      });
+    });
+
+    it('should ignore novels that are not in the library', async () => {
+      const testDb = getTestDb();
+
+      const libraryNovelId = await insertTestNovel(testDb, { inLibrary: true });
+      const nonLibraryNovelId = await insertTestNovel(testDb, { inLibrary: false });
+
+      await insertTestChapter(testDb, libraryNovelId, { timeSpent: 150 });
+      await insertTestChapter(testDb, nonLibraryNovelId, { timeSpent: 999 });
+
+      const result = await getTopNovelsByTimeSpentFromDb();
+
+      expect(result.topNovelsByTimeSpent).toHaveLength(1);
+      expect(result.topNovelsByTimeSpent!![0].id).toBe(libraryNovelId);
+    });
+
+    it('should exclude novels with 0 or null time spent', async () => {
+      const testDb = getTestDb();
+
+      const novelId1 = await insertTestNovel(testDb, { inLibrary: true });
+      const novelId2 = await insertTestNovel(testDb, { inLibrary: true });
+
+      await insertTestChapter(testDb, novelId1, { timeSpent: 0 });
+      await insertTestChapter(testDb, novelId2, { timeSpent: null });
+
+      const result = await getTopNovelsByTimeSpentFromDb();
+
+      expect(result.topNovelsByTimeSpent).toEqual([]);
+    });
+
+    it('should respect the limit of 10 items', async () => {
+      const testDb = getTestDb();
+
+      for (let i = 1; i <= 12; i++) {
+        const novelId = await insertTestNovel(testDb, {
+          name: `Novel ${i}`,
+          inLibrary: true,
+        });
+        await insertTestChapter(testDb, novelId, { timeSpent: i * 10 });
+      }
+
+      const result = await getTopNovelsByTimeSpentFromDb();
+
+      expect(result.topNovelsByTimeSpent).toHaveLength(10);
+      expect(result.topNovelsByTimeSpent!![0].name).toBe('Novel 12');
+    });
+  });
+
+  describe('getTopCategoriesByTimeSpentFromDb', () => {
+    it('should return categories ordered by accumulated time spent', async () => {
+      const testDb = getTestDb();
+
+      // Create categories
+      const fantasyCat = await insertTestCategory(testDb, { name: 'Fantasy' });
+      const scifiCat = await insertTestCategory(testDb, { name: 'Sci-Fi' });
+
+      // Create novels
+      const novel1 = await insertTestNovel(testDb, { inLibrary: true });
+      const novel2 = await insertTestNovel(testDb, { inLibrary: true });
+
+      await insertTestNovelCategory(testDb, novel1, fantasyCat);
+      await insertTestNovelCategory(testDb, novel2, scifiCat);
+
+      await insertTestChapter(testDb, novel1, { timeSpent: 100 });
+      await insertTestChapter(testDb, novel2, { timeSpent: 300 });
+
+      const result = await getTopCategoriesByTimeSpentFromDb();
+
+      expect(result.topCategoriesByTimeSpent).toHaveLength(2);
+      expect(result.topCategoriesByTimeSpent!![0]).toMatchObject({
+        id: scifiCat,
+        name: 'Sci-Fi',
+        timeSpent: 300,
+      });
+      expect(result.topCategoriesByTimeSpent!![1]).toMatchObject({
+        id: fantasyCat,
+        name: 'Fantasy',
+        timeSpent: 100,
+      });
+    });
+
+    it('should sum timeSpent across multiple novels in the same category', async () => {
+      const testDb = getTestDb();
+
+      const catId = await insertTestCategory(testDb, { name: 'Action' });
+
+      const novel1 = await insertTestNovel(testDb, { inLibrary: true });
+      const novel2 = await insertTestNovel(testDb, { inLibrary: true });
+
+      await insertTestNovelCategory(testDb, novel1, catId);
+      await insertTestNovelCategory(testDb, novel2, catId);
+
+      await insertTestChapter(testDb, novel1, { timeSpent: 200 });
+      await insertTestChapter(testDb, novel2, { timeSpent: 150 });
+
+      const result = await getTopCategoriesByTimeSpentFromDb();
+
+      expect(result.topCategoriesByTimeSpent).toHaveLength(1);
+      expect(result.topCategoriesByTimeSpent!![0].timeSpent).toBe(350);
+    });
+
+    it('should return an empty array when no category chapters have spent time', async () => {
+      const result = await getTopCategoriesByTimeSpentFromDb();
+
+      expect(result.topCategoriesByTimeSpent).toEqual([]);
+    });
+  });
+
+  describe('getTotalTimeSpentFromDb', () => {
+    it('should sum timeSpent across all chapters', async () => {
+      const testDb = getTestDb();
+
+      const novelId = await insertTestNovel(testDb, { inLibrary: true });
+
+      await insertTestChapter(testDb, novelId, { timeSpent: 120 });
+      await insertTestChapter(testDb, novelId, { timeSpent: 180 });
+      await insertTestChapter(testDb, novelId, { timeSpent: 50 });
+
+      const result = await getTotalTimeSpentFromDb();
+
+      expect(result.totalTimeSpent).toBe(350);
+    });
+
+    it('should return 0 when there are no chapters or total is null/zero', async () => {
+      const result = await getTotalTimeSpentFromDb();
+
+      expect(result.totalTimeSpent).toBe(0);
     });
   });
 });

--- a/src/database/queries/__tests__/testData.ts
+++ b/src/database/queries/__tests__/testData.ts
@@ -91,6 +91,7 @@ export async function insertTestChapter(
     position: 0,
     progress: null,
     scanlator: null,
+	timeSpent: 0,
     ...data,
     novelId,
   };

--- a/src/database/queries/__tests__/testDb.ts
+++ b/src/database/queries/__tests__/testDb.ts
@@ -43,7 +43,8 @@ const MIGRATION_STATEMENTS = [
 	page text DEFAULT '1',
 	position integer DEFAULT 0,
 	progress integer,
-	scanlator text
+	scanlator text,
+	timeSpent integer DEFAULT 0
 )`,
   `CREATE UNIQUE INDEX IF NOT EXISTS chapter_novel_path_unique ON Chapter (novelId, path)`,
   `CREATE INDEX IF NOT EXISTS chapterNovelIdIndex ON Chapter (novelId, position, page, id)`,

--- a/src/database/schema/chapter.ts
+++ b/src/database/schema/chapter.ts
@@ -25,6 +25,7 @@ export const chapter = sqliteTable(
     position: integer('position').default(0),
     progress: integer('progress'),
     scanlator: text('scanlator'),
+    timeSpent: integer('timeSpent').default(0),
   },
   table => [
     uniqueIndex('chapter_novel_path_unique').on(table.novelId, table.path),

--- a/src/database/types/index.ts
+++ b/src/database/types/index.ts
@@ -40,6 +40,7 @@ export interface ChapterInfo {
   progress: number | null;
   position?: number | null;
   scanlator?: string | null;
+  timeSpent: number | null;
 }
 
 export interface DownloadedChapter extends ChapterInfo {
@@ -97,6 +98,19 @@ export interface LibraryStats {
   sourcesCount?: number;
   genres?: Record<string, number>;
   status?: Record<string, number>;
+  totalTimeSpent?: number;
+  topNovelsByTimeSpent?: {
+    id: number;
+    pluginId: string;
+    name: string;
+    cover: string | null;
+    timeSpent: number;
+  }[];
+  topCategoriesByTimeSpent?: {
+	id: number;
+	name: string;
+	timeSpent: number;
+  }[];
 }
 
 export interface BackupNovel extends NovelInfo {

--- a/src/hooks/persisted/useNovel/__tests__/chapterActions.test.ts
+++ b/src/hooks/persisted/useNovel/__tests__/chapterActions.test.ts
@@ -5,6 +5,7 @@ import {
   ChapterActionsDependencies,
   deleteChapterAction,
   deleteChaptersAction,
+  increaseTimeSpentAction,
   markChapterReadAction,
   markChaptersReadAction,
   markChaptersUnreadAction,
@@ -29,6 +30,7 @@ const makeChapter = (id: number, overrides: Partial<ChapterInfo> = {}) => ({
   page: '1',
   progress: 0,
   position: id - 1,
+  timeSpent: 0,
   ...overrides,
 });
 
@@ -50,6 +52,7 @@ const createDeps = (): jest.Mocked<ChapterActionsDependencies> => ({
   deleteChapter: jest.fn().mockResolvedValue(undefined),
   deleteChapters: jest.fn().mockResolvedValue(undefined),
   getPageChapters: jest.fn().mockResolvedValue([]),
+  increaseTimeSpent: jest.fn().mockResolvedValue(undefined),
   showToast: jest.fn(),
   getString: jest
     .fn<
@@ -277,4 +280,50 @@ describe('chapterActions', () => {
       expect.objectContaining({ id: 2, unread: false }),
     ]);
   });
+  it('increaseTimeSpentAction accumulates timeSpent in db and state', () => {
+	const deps = createDeps();
+	const state = createStateMutator([
+		makeChapter(1, { timeSpent: 500 }),
+		makeChapter(2, { timeSpent: 500 }),
+	]);
+
+	increaseTimeSpentAction(1, 200, state.mutate, deps);
+
+	expect(deps.increaseTimeSpent).toHaveBeenCalledWith(1, 200);
+	expect(state.getState().map(ch => ch.timeSpent)).toEqual([700, 500]);
+	});
+
+	it('increaseTimeSpentAction treats a missing timeSpent as 0 before adding', () => {
+	const deps = createDeps();
+	const state = createStateMutator([
+		makeChapter(1, { timeSpent: undefined }),
+	]);
+
+	increaseTimeSpentAction(1, 300, state.mutate, deps);
+
+	expect(deps.increaseTimeSpent).toHaveBeenCalledWith(1, 300);
+	expect(state.getState()[0].timeSpent).toBe(300);
+	});
+
+	it('increaseTimeSpentAction is a no-op on state for a chapterId not present', () => {
+	const deps = createDeps();
+	const state = createStateMutator([makeChapter(1, { timeSpent: 500 })]);
+
+	increaseTimeSpentAction(999, 200, state.mutate, deps);
+
+	expect(deps.increaseTimeSpent).toHaveBeenCalledWith(999, 200);
+	expect(state.getState().map(ch => ch.timeSpent)).toEqual([500]);
+	});
+
+	it('increaseTimeSpentAction supports repeated calls accumulating on the same chapter', () => {
+	const deps = createDeps();
+	const state = createStateMutator([makeChapter(1, { timeSpent: 0 })]);
+
+	increaseTimeSpentAction(1, 100, state.mutate, deps);
+	increaseTimeSpentAction(1, 150, state.mutate, deps);
+
+	expect(deps.increaseTimeSpent).toHaveBeenNthCalledWith(1, 1, 100);
+	expect(deps.increaseTimeSpent).toHaveBeenNthCalledWith(2, 1, 150);
+	expect(state.getState()[0].timeSpent).toBe(250);
+	});
 });

--- a/src/hooks/persisted/useNovel/__tests__/novelStore.chapterActions.test.ts
+++ b/src/hooks/persisted/useNovel/__tests__/novelStore.chapterActions.test.ts
@@ -6,6 +6,7 @@ import {
   ChapterActionsDependencies,
   deleteChapterAction,
   deleteChaptersAction,
+  increaseTimeSpentAction,
   markChapterReadAction,
   markChaptersReadAction,
   markChaptersUnreadAction,
@@ -31,6 +32,7 @@ jest.mock('../store/chapterActions', () => {
     markPreviousChaptersUnreadAction: jest.fn(),
     refreshChaptersAction: jest.fn(),
     updateChapterProgressAction: jest.fn(),
+    increaseTimeSpentAction: jest.fn(),
   };
 });
 
@@ -65,6 +67,7 @@ const makeChapter = (id: number, overrides: Partial<ChapterInfo> = {}) => ({
   page: '1',
   progress: 0,
   position: id - 1,
+  timeSpent: 0,
   ...overrides,
 });
 
@@ -86,6 +89,7 @@ const createDeps = (): jest.Mocked<ChapterActionsDependencies> => ({
   deleteChapter: jest.fn().mockResolvedValue(undefined),
   deleteChapters: jest.fn().mockResolvedValue(undefined),
   getPageChapters: jest.fn().mockResolvedValue([]),
+  increaseTimeSpent: jest.fn().mockResolvedValue(undefined),
   showToast: jest.fn(),
   getString: jest
     .fn<
@@ -405,5 +409,29 @@ describe('novelStore.chapterActions', () => {
       expect.any(Function),
       harness.chapterDeps,
     );
+  });
+  it('increaseTimeSpent delegates mutation to low-level action with dependencies', () => {
+    const harness = createHarness();
+    (
+      increaseTimeSpentAction as jest.MockedFunction<typeof increaseTimeSpentAction>
+    ).mockImplementation((chapterId, timeSpent, mutate) => {
+      mutate(chs =>
+        chs.map(ch =>
+          ch.id === chapterId
+            ? { ...ch, timeSpent: (ch.timeSpent ?? 0) + timeSpent }
+            : ch,
+        ),
+      );
+    });
+
+    harness.actions.increaseTimeSpent(1, 200);
+
+    expect(increaseTimeSpentAction).toHaveBeenCalledWith(
+      1,
+      200,
+      expect.any(Function),
+      harness.chapterDeps,
+    );
+    expect(harness.getState().chapters[0].timeSpent).toBe(200);
   });
 });

--- a/src/hooks/persisted/useNovel/store/chapterActions.ts
+++ b/src/hooks/persisted/useNovel/store/chapterActions.ts
@@ -10,6 +10,7 @@ import {
   markPreviousChaptersUnread as _markPreviousChaptersUnread,
   markPreviuschaptersRead as _markPreviuschaptersRead,
   updateChapterProgress as _updateChapterProgress,
+  increaseTimeSpent as _increaseTimeSpent,
 } from '@database/queries/ChapterQueries';
 import { ChapterInfo, NovelInfo } from '@database/types';
 import { getString as translateGetString } from '@strings/translations';
@@ -49,6 +50,7 @@ export interface ChapterActionsDependencies {
     filter?: ChapterFilterKey[],
     page?: string,
   ) => Promise<ChapterInfo[]>;
+  increaseTimeSpent: (chapterId: number, timeSpent: number) => Promise<void>;
   showToast: (message: string) => void;
   getString: typeof translateGetString;
 }
@@ -64,6 +66,7 @@ export const defaultChapterActionsDependencies: ChapterActionsDependencies = {
   deleteChapter: _deleteChapter,
   deleteChapters: _deleteChapters,
   getPageChapters: _getPageChapters,
+  increaseTimeSpent: _increaseTimeSpent,
   showToast,
   getString: translateGetString,
 };
@@ -326,3 +329,25 @@ export const refreshChaptersAction = ({
     );
   }
 };
+
+export function increaseTimeSpentAction(
+  chapterId: number,
+  timeSpent: number,
+  mutateChapters: MutateChapters,
+  deps: ChapterActionsDependencies = defaultChapterActionsDependencies,
+) {
+  runAsyncAction(
+    deps.increaseTimeSpent(chapterId, timeSpent),
+    deps,
+  );
+
+  mutateChapters(chapters =>
+    chapters.map(ch =>
+      ch.id === chapterId
+        ? {
+          ...ch, timeSpent: (ch.timeSpent ?? 0) + timeSpent
+        }
+        : ch
+    )
+  );
+}

--- a/src/hooks/persisted/useNovel/store/novelStore.chapterActions.ts
+++ b/src/hooks/persisted/useNovel/store/novelStore.chapterActions.ts
@@ -6,6 +6,7 @@ import {
   ChapterActionsDependencies,
   deleteChapterAction,
   deleteChaptersAction,
+  increaseTimeSpentAction,
   markChapterReadAction,
   markChaptersReadAction,
   markChaptersUnreadAction,
@@ -291,5 +292,14 @@ export const createNovelStoreChapterActions = ({
         deps: chapterActionsDependencies,
       });
     },
+
+	increaseTimeSpent: (chapterId, timeSpent) => {
+	  increaseTimeSpentAction(
+		chapterId,
+		timeSpent,
+		mutateChapters,
+		chapterActionsDependencies,
+	  );
+	}
   };
 };

--- a/src/hooks/persisted/useNovel/store/novelStore.types.ts
+++ b/src/hooks/persisted/useNovel/store/novelStore.types.ts
@@ -52,6 +52,7 @@ export interface NovelStoreChapterActions {
   deleteChapter: (chapter: ChapterInfo) => void;
   deleteChapters: (chapters: ChapterInfo[]) => void;
   refreshChapters: () => void;
+  increaseTimeSpent: (chapterId: number, timeSpent: number) => void;
 }
 
 export interface NovelStoreNovelActions {

--- a/src/screens/StatsScreen/StatsScreen.tsx
+++ b/src/screens/StatsScreen/StatsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View, Image } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import { useTheme } from '@hooks/persisted';
@@ -21,10 +21,47 @@ import {
   getLibraryStatsFromDb,
   getNovelGenresFromDb,
   getNovelStatusFromDb,
+  getTopCategoriesByTimeSpentFromDb,
+  getTopNovelsByTimeSpentFromDb,
+  getTotalTimeSpentFromDb,
 } from '@database/queries/StatsQueries';
 import { Row } from '@components/Common';
-import { overlay } from 'react-native-paper';
+import { IconButton, overlay } from 'react-native-paper';
 import { translateNovelStatus } from '@utils/translateEnum';
+import dayjs from 'dayjs';
+import { getUserAgent } from '@hooks/persisted/useUserAgent';
+import { getPlugin } from '@plugins/pluginManager';
+
+function formatTimeSpent(totalMs: number | undefined) {
+  if (totalMs === undefined || totalMs <= 0) {
+    return getString('time.seconds', { count: 0 });
+  }
+  const d = dayjs.duration(totalMs, 'milliseconds');
+  const asDays = Math.floor(d.asDays());
+  const asHours = Math.floor(d.asHours());
+  const asMinutes = Math.floor(d.asMinutes());
+  const asSeconds = Math.floor(d.asSeconds());
+  const hours = Math.floor(d.hours());
+  const minutes = Math.floor(d.minutes());
+  const seconds = Math.floor(d.seconds());
+
+  if (asDays >= 1) {
+    return hours > 0
+        ? `${getString('time.days', { count: asDays })} ${getString('time.hours', { count: hours })}`
+        : getString('time.days', { count: asDays });
+  }
+  if (asHours >= 1) {
+      return minutes > 0
+          ? `${getString('time.hours', { count: asHours })} ${getString('time.minutes', { count: minutes })}`
+          : getString('time.hours', { count: asHours });
+  }
+  if (asMinutes >= 1) {
+    return seconds > 0
+      ? `${getString('time.minutes', { count: asMinutes })} ${getString('time.seconds', { count: seconds })}`
+      : getString('time.minutes', { count: asMinutes });
+  }
+  return getString('time.seconds', { count: asSeconds });
+}
 
 const StatsScreen = () => {
   const theme = useTheme();
@@ -33,6 +70,8 @@ const StatsScreen = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [stats, setStats] = useState<LibraryStats>({});
   const [error, setError] = useState<any>();
+
+  const [showingNovels, setShowingNovels] = useState(true);
 
   const getStats = async () => {
     try {
@@ -44,6 +83,9 @@ const StatsScreen = () => {
         getChaptersDownloadedCountFromDb(),
         getNovelGenresFromDb(),
         getNovelStatusFromDb(),
+        getTopNovelsByTimeSpentFromDb(),
+        getTopCategoriesByTimeSpentFromDb(),
+        getTotalTimeSpentFromDb(),
       ]);
       setStats(Object.assign(...res));
     } catch (err) {
@@ -98,6 +140,12 @@ const StatsScreen = () => {
             value={stats.novelsCount}
           />
           <StatsCard
+            label={getString('statsScreen.totalTimeSpent')}
+            value={formatTimeSpent(stats.totalTimeSpent)}
+          />
+        </Row>
+        <Row style={styles.statsRow}>
+          <StatsCard
             label={getString('statsScreen.readChapters')}
             value={stats.chaptersRead}
           />
@@ -142,6 +190,50 @@ const StatsScreen = () => {
             />
           ))}
         </Row>
+      <View style={styles.timeSpentHeader}>
+        <Text style={[styles.header, { color: theme.onSurfaceVariant }]}>
+          {showingNovels ? getString('statsScreen.topNovelsByTimeSpent') : getString('statsScreen.topCategoriesByTimeSpent')}
+        </Text>
+        <IconButton
+          icon={showingNovels ? 'label-outline' : 'book'}
+          iconColor={theme.onSurfaceVariant}
+          onPress={() => setShowingNovels(!showingNovels)}
+          accessibilityRole="button"
+          accessibilityLabel={showingNovels ? getString('statsScreen.showCategories') : getString('statsScreen.showNovels')}
+          />
+      </View>
+        {showingNovels && stats.topNovelsByTimeSpent?.map((novel, _) => {
+          const plugin = getPlugin(novel.pluginId);
+          const headers = plugin?.imageRequestInit?.headers || { 'User-Agent': getUserAgent() };
+          const requestInit = {...plugin?.imageRequestInit, headers };
+          return <View key={novel.id} style={styles.timeSpentRow}>
+            <Image
+              source={{ uri: novel.cover || undefined, ...requestInit }}
+              style={styles.timeSpentNovelCover}
+              resizeMode='cover'
+            />
+            <View>
+              <Text style={[styles.timeSpentLabel, { color: theme.onSurface }]}>
+                {novel.name}
+              </Text>
+              <Text style={{ color: theme.onSurfaceVariant }}>
+                {formatTimeSpent(novel.timeSpent)}
+              </Text>
+            </View>
+          </View>
+        })}
+        {!showingNovels && stats.topCategoriesByTimeSpent?.map((category, _) => {
+          return <View key={category.id} style={styles.timeSpentRow}>
+            <View>
+              <Text style={[styles.timeSpentLabel, { color: theme.onSurface }]}>
+                {category.name}
+              </Text>
+              <Text style={{ color: theme.onSurfaceVariant }}>
+                {formatTimeSpent(category.timeSpent)}
+              </Text>
+            </View>
+          </View>
+        })}
       </ScrollView>
     </SafeAreaView>
   );
@@ -149,7 +241,7 @@ const StatsScreen = () => {
 
 export default StatsScreen;
 
-export const StatsCard: React.FC<{ label: string; value?: number }> = ({
+export const StatsCard: React.FC<{ label: string; value?: string | number }> = ({
   label,
   value = 0,
 }) => {
@@ -205,6 +297,25 @@ const styles = StyleSheet.create({
   },
   statsVal: {
     fontSize: 16,
+    fontWeight: 'bold',
+  },
+  timeSpentHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  timeSpentRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  timeSpentNovelCover: {
+    width: 50,
+    aspectRatio: 2 / 3,
+    marginRight: 8,
+    borderRadius: 4,
+  },
+  timeSpentLabel: {
     fontWeight: 'bold',
   },
 });

--- a/src/screens/reader/components/WebViewReader.tsx
+++ b/src/screens/reader/components/WebViewReader.tsx
@@ -222,51 +222,37 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
     const mmkvListener = MMKVStorage.addOnValueChangedListener(key => {
       switch (key) {
         case CHAPTER_READER_SETTINGS: {
-            // Update reader settings
-            const newReaderSettings = getMMKVObject<ChapterReaderSettings>(CHAPTER_READER_SETTINGS) || initialChapterReaderSettings;
-            setReaderSettings(newReaderSettings);
-            // Check if the new TTS settings are different from the current ones, so the changes apply instantly and not after finishing the current paragraph
-            if (!areTTSSettingsEqual(readerSettingsRef.current.tts, newReaderSettings.tts)) {
-                // Stop any currently playing speech
-                Speech.stop();
-                // Restart TTS if it was reading before the settings change
-                webViewRef.current?.injectJavaScript(
-                    `
-                    // Auto-restart TTS if currently reading
-                    if (window.tts && tts.reading) {
-                        const currentElement = tts.currentElement;
-                        const wasReading = tts.reading;
-                        tts.stop();
-                        if (wasReading) {
-                            setTimeout(() => {
-                            tts.start(currentElement);
-                            }, 100);
-                        }
-                    }
-                    `,
-                );
-            }
-            // Update WebView settings
+          // Update reader settings
+          const newReaderSettings = getMMKVObject<ChapterReaderSettings>(CHAPTER_READER_SETTINGS) || initialChapterReaderSettings;
+          setReaderSettings(newReaderSettings);
+          // Check if the new TTS settings are different from the current ones, so the changes apply instantly and not after finishing the current paragraph
+          if (!areTTSSettingsEqual(readerSettingsRef.current.tts, newReaderSettings.tts)) {
+            // Stop any currently playing speech
+            Speech.stop();
+            // Restart TTS if it was reading before the settings change
             webViewRef.current?.injectJavaScript(
-                `
-                (function() {
-                    const s = ${MMKVStorage.getString(CHAPTER_READER_SETTINGS)};
-                    reader.readerSettings.val = s;
-                    const root = document.documentElement.style;
-                    root.setProperty('--readerSettings-theme', s.theme);
-                    root.setProperty('--readerSettings-padding', s.padding + 'px');
-                    root.setProperty('--readerSettings-textSize', s.textSize + 'px');
-                    root.setProperty('--readerSettings-textColor', s.textColor);
-                    root.setProperty('--readerSettings-textAlign', s.textAlign);
-                    root.setProperty('--readerSettings-lineHeight', s.lineHeight);
-                    root.setProperty('--readerSettings-fontFamily', s.fontFamily);
-                    document.getElementById('ln-custom-css').innerHTML = s.customCSS;
-                    document.getElementById('ln-font').innerHTML = \`@font-face { font-family: \${s.fontFamily}; src: url("file:///android_asset/fonts/\${s.fontFamily}.ttf"); }\`;
-                    document.getElementById('ln-custom-js').innerHTML = s.customJS;
-                })();
-                `,
+              `
+              // Auto-restart TTS if currently reading
+              if (window.tts && tts.reading) {
+                const currentElement = tts.currentElement;
+                const wasReading = tts.reading;
+                tts.stop();
+                if (wasReading) {
+                  setTimeout(() => {
+                    tts.start(currentElement);
+                  }, 100);
+                }
+              }
+              `,
             );
-            break;
+          }
+          // Update WebView settings
+          webViewRef.current?.injectJavaScript(
+            `
+            reader.readerSettings.val = ${JSON.stringify(newReaderSettings)}
+            `,
+          );
+          break;
         }
         case CHAPTER_GENERAL_SETTINGS:
           webViewRef.current?.injectJavaScript(

--- a/src/screens/reader/hooks/__tests__/useChapter.test.ts
+++ b/src/screens/reader/hooks/__tests__/useChapter.test.ts
@@ -81,6 +81,7 @@ const makeChapter = (id: number, page = '1') => ({
   releaseTime: '2026-01-01',
   updatedTime: '2026-01-01',
   readTime: '2026-01-01',
+  timeSpent: 0,
 });
 
 const makeNovel = () => ({
@@ -124,6 +125,7 @@ const createStore = (
     updateChapterProgress: jest.fn(),
     chapterTextCache,
     setLastRead: jest.fn(),
+	increaseTimeSpent: jest.fn()
   };
 
   return {

--- a/src/screens/reader/hooks/__tests__/useTimeTracking.test.ts
+++ b/src/screens/reader/hooks/__tests__/useTimeTracking.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react-native';
+import useTimeTracking from '../useTimeTracking';
+
+// Capture the listener so tests can fire fake AppState events
+let appStateHandler: (state: string) => void;
+
+jest.mock('react-native', () => {
+  return {
+    AppState: {
+      currentState: 'active',
+      addEventListener: jest.fn((_event, handler) => {
+        appStateHandler = handler;
+        return { remove: jest.fn() };
+      }),
+    },
+  };
+});
+
+describe('useTimeTracking', () => {
+  const increaseTimeSpent = jest.fn();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('flushes elapsed time on the 60s interval', () => {
+    renderHook(() => useTimeTracking(1, false, increaseTimeSpent));
+
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+
+    expect(increaseTimeSpent).toHaveBeenCalledWith(1, expect.any(Number));
+    const elapsed = increaseTimeSpent.mock.calls[0][1];
+    expect(elapsed).toBeGreaterThanOrEqual(60000);
+  });
+
+  it('flushes when the app goes to the background', () => {
+    renderHook(() => useTimeTracking(1, false, increaseTimeSpent));
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+      appStateHandler('background');
+    });
+
+    expect(increaseTimeSpent).toHaveBeenCalledWith(1, expect.any(Number));
+  });
+
+  it('does not double count after backgrounding and foregrounding', () => {
+    renderHook(() => useTimeTracking(1, false, increaseTimeSpent));
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+      appStateHandler('background'); // flush 5s
+      jest.advanceTimersByTime(20000);
+      appStateHandler('active');
+      jest.advanceTimersByTime(3000);
+      appStateHandler('background'); // flush 3s
+    });
+
+	const firstElapsed = increaseTimeSpent.mock.calls[0][1];
+	expect(firstElapsed).toBeLessThan(6000); // 5s flush
+	const secondElapsed = increaseTimeSpent.mock.calls[1][1];
+	expect(secondElapsed).toBeLessThan(4000); // 3s flush
+  });
+
+  it('flushes remaining time on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useTimeTracking(1, false, increaseTimeSpent),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    unmount();
+
+    expect(increaseTimeSpent).toHaveBeenLastCalledWith(1, expect.any(Number));
+  });
+
+  it('flushes for the previous chapter id when chapterId changes', () => {
+    const { rerender } = renderHook(
+      ({ chapterId }: { chapterId: number }) => useTimeTracking(chapterId, false, increaseTimeSpent),
+      { initialProps: { chapterId: 1 } },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    rerender({ chapterId: 2 });
+
+    expect(increaseTimeSpent).toHaveBeenCalledWith(1, expect.any(Number));
+    expect(increaseTimeSpent).not.toHaveBeenCalledWith(2, expect.any(Number));
+  });
+
+  it('does not track time in incognito mode', () => {
+    renderHook(() => useTimeTracking(1, true, increaseTimeSpent));
+
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+
+    expect(increaseTimeSpent).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/reader/hooks/useChapter.ts
+++ b/src/screens/reader/hooks/useChapter.ts
@@ -35,6 +35,7 @@ import { getString } from '@strings/translations';
 import NativeVolumeButtonListener from '@specs/NativeVolumeButtonListener';
 import NativeFile from '@specs/NativeFile';
 import { useNovelActions, useNovelValue } from '@screens/novel/NovelContext';
+import useTimeTracking from './useTimeTracking';
 
 const emmiter = new NativeEventEmitter(NativeVolumeButtonListener);
 
@@ -47,6 +48,7 @@ export default function useChapter(
     setLastRead,
     markChapterRead,
     updateChapterProgress,
+    increaseTimeSpent,
     chapterTextCache,
   } = useNovelActions();
   const novelSettings = useNovelValue('novelSettings');
@@ -71,6 +73,8 @@ export default function useChapter(
   const { tracker } = useTracker();
   const { trackedNovel, updateAllTrackedNovels } = useTrackedNovel(novel.id);
   const { setImmersiveMode, showStatusAndNavBar } = useFullscreenMode();
+
+  useTimeTracking(chapter.id, incognitoMode || false, increaseTimeSpent);
 
   const connectVolumeButton = useCallback(() => {
     const offset = defaultTo(
@@ -356,6 +360,8 @@ export default function useChapter(
     [getChapter, nextChapter, prevChapter],
   );
 
+
+  // Cleanup when the component unmounts or the chapter changes
   useEffect(() => {
     if (!incognitoMode) {
       insertHistory(chapter.id);

--- a/src/screens/reader/hooks/useTimeTracking.ts
+++ b/src/screens/reader/hooks/useTimeTracking.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+
+
+/**
+ * Starts tracking time spent on the chapter, and flushes the data to the database:
+ * - periodically every minute
+ * - when the app goes in the background
+ * - when the chapter changes
+ */
+export default function useTimeTracking(
+  chapterId: number,
+  incognitoMode: boolean,
+  increaseTimeSpent: (chapterId: number, elapsed: number) => void,
+) {
+  const startTimestampRef = useRef(Date.now());
+
+  /** Increases the time spent on the current chapter since the last time this function was called */
+  const flushElapsedTime = useCallback(() => {
+    if (!incognitoMode) {
+      const elapsed = Date.now() - startTimestampRef.current;
+      if (elapsed > 0) {
+        increaseTimeSpent(chapterId, elapsed);
+      }
+    }
+    startTimestampRef.current = Date.now();
+  }, [chapterId, incognitoMode, increaseTimeSpent]);
+
+  // Flush the elapsed time every minute
+  useEffect(() => {
+    const intervalId = setInterval(flushElapsedTime, 60000);
+    return () => clearInterval(intervalId);
+  }, [flushElapsedTime]);
+
+  // Flush the elapsed time when the app goes in the background
+  useEffect(() => {
+    let appState = AppState.currentState;
+    const handleChange = (nextState: AppStateStatus) => {
+      if (appState === 'active' && nextState.match(/inactive|background/)) {
+        // Save the elapsed time when the app goes in the background
+        flushElapsedTime();
+      } else if (appState.match(/inactive|background/) && nextState === 'active') {
+        // Reset the start timestamp when the app comes back
+        startTimestampRef.current = Date.now();
+      }
+      appState = nextState;
+    };
+    const sub = AppState.addEventListener('change', handleChange);
+    return () => sub.remove();
+  }, [flushElapsedTime]);
+
+  // Flush the elapsed time when the chapter changes
+  useEffect(() => {
+    startTimestampRef.current = Date.now();
+    return () => {
+      flushElapsedTime();
+    };
+  }, [chapterId, flushElapsedTime]);
+}

--- a/strings/languages/en/strings.json
+++ b/strings/languages/en/strings.json
@@ -538,7 +538,12 @@
     "title": "Statistics",
     "titlesInLibrary": "Titles in library",
     "totalChapters": "Total chapters",
-    "unreadChapters": "Unread chapters"
+    "unreadChapters": "Unread chapters",
+    "topNovelsByTimeSpent": "Top novels by time spent",
+    "topCategoriesByTimeSpent": "Top categories by time spent",
+    "totalTimeSpent": "Total time spent",
+	"showNovels": "Group by novel",
+	"showCategories": "Group by category"
   },
   "tracking": "Tracking",
   "trackingScreen": {
@@ -578,5 +583,23 @@
     "LOCAL_RESTORE": "Local Restore",
     "MIGRATE_NOVEL": "Migrating Novel",
     "DOWNLOAD_CHAPTER": "Downloading Chapter"
+  },
+  "time": {
+    "seconds": {
+      "one": "%{count} second",
+      "other": "%{count} seconds"
+    },
+    "minutes": {
+      "one": "%{count} minute",
+      "other": "%{count} minutes"
+    },
+    "hours": {
+      "one": "%{count} hour",
+      "other": "%{count} hours"
+    },
+    "days": {
+      "one": "%{count} day",
+      "other": "%{count} days"
+    }
   }
 }

--- a/strings/translations.ts
+++ b/strings/translations.ts
@@ -8,11 +8,13 @@ import localeData from 'dayjs/plugin/localeData';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import calendar from 'dayjs/plugin/calendar';
+import duration from 'dayjs/plugin/duration';
 dayjs.extend(customParseFormat);
 dayjs.extend(localeData);
 dayjs.extend(localizedFormat);
 dayjs.extend(relativeTime);
 dayjs.extend(calendar);
+dayjs.extend(duration);
 
 import 'dayjs/locale/ar';
 import 'dayjs/locale/ca';
@@ -163,8 +165,12 @@ export const setLocale = (locale: string) => {
 
 export { i18n };
 
+type PluralSuffix = '.one' | '.other';
+
+type TrimPlural<T extends string> = T extends `${infer Base}${PluralSuffix}` ? Base : T;
+
 export const getString = (
-  stringKey: keyof StringMap,
+  stringKey: keyof StringMap | TrimPlural<keyof StringMap>,
   options?: TranslateOptions,
 ) => i18n.t(stringKey, options);
 

--- a/strings/types/index.ts
+++ b/strings/types/index.ts
@@ -317,8 +317,8 @@ export interface StringMap {
   'novelScreen.bottomSheet.displays.sourceTitle': 'string';
   'novelScreen.bottomSheet.filters.bookmarked': 'string';
   'novelScreen.bottomSheet.filters.downloaded': 'string';
-  'novelScreen.bottomSheet.filters.scanlators': 'string';
   'novelScreen.bottomSheet.filters.unread': 'string';
+  'novelScreen.bottomSheet.filters.scanlators': 'string';
   'novelScreen.bottomSheet.order.byChapterName': 'string';
   'novelScreen.bottomSheet.order.bySource': 'string';
   'novelScreen.chapterChapnum': 'string';
@@ -448,6 +448,11 @@ export interface StringMap {
   'statsScreen.titlesInLibrary': 'string';
   'statsScreen.totalChapters': 'string';
   'statsScreen.unreadChapters': 'string';
+  'statsScreen.topNovelsByTimeSpent': 'string';
+  'statsScreen.topCategoriesByTimeSpent': 'string';
+  'statsScreen.totalTimeSpent': 'string';
+  'statsScreen.showNovels': 'string';
+  'statsScreen.showCategories': 'string';
   'tracking': 'string';
   'trackingScreen.logOutMessage': 'string';
   'trackingScreen.revalidate': 'string';
@@ -479,4 +484,12 @@ export interface StringMap {
   'notifications.LOCAL_RESTORE': 'string';
   'notifications.MIGRATE_NOVEL': 'string';
   'notifications.DOWNLOAD_CHAPTER': 'string';
+  'time.seconds.one': 'string';
+  'time.seconds.other': 'string';
+  'time.minutes.one': 'string';
+  'time.minutes.other': 'string';
+  'time.hours.one': 'string';
+  'time.hours.other': 'string';
+  'time.days.one': 'string';
+  'time.days.other': 'string';
 }


### PR DESCRIPTION
### Feature
Tracks how long the user spends reading each individual chapter in non-incognito mode, and shows the data inside the statistics screen.
- New `StatsCard` showing total time spent reading (including novels not in the library)
- New section showing the top 10 novels/categories by time spent, with ability to switch between modes

### Implementation
- `useTimeTracking` stores the timestamp of when the current chapter was opened
- When the current chapter changes (because the user navigated to another chapter), the useEffect ends (because the user navigated away from the reader), when the app state changes, and periodically every minute, we write add the elapsed time to a new database column on the current chapter, and reset the elapsed time.
- The stats screen sums up the time spent in total and for each novel/category, and displays them
- The new `useTimeTracking` hook and changes inside the chapter actions, stats queries and chapter queries are fully covered by tests
- The chapter schema in the database received a new `timeSpent` column and was migrated
- I removed some redundant code from a previous PR

Any feedback is welcome

Addresses: #1743 #1168

### Screenshots
**Sorted by Novel:**
<img width="864" height="1920" alt="Screenshot_20260720-182233" src="https://github.com/user-attachments/assets/4ee27474-9289-4fa8-8867-809e09d1de84" />
**Sorted by Category:**
<img width="864" height="1920" alt="Screenshot_20260720-182238" src="https://github.com/user-attachments/assets/d762f3fb-dc3d-4581-85e2-874c71b42f0f" />
**Total Time:**
<img width="864" height="1920" alt="Screenshot_20260720-182228" src="https://github.com/user-attachments/assets/0798d60a-27d0-48c6-8195-9fb419d52fb8" />