### PR TITLE
docs: fix trailing period, organization expansion, and comma in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,11 @@ Contributions are welcome and are greatly appreciated!
 ## Setup Your Environment with Nix
 
 If you are on a Linux system, you can install the nix package manager and use the nix flakes to set up your development environment.
-See [CONTRIBUTING-NIX.md](CONTRIBUTING-NIX.md)
+See [CONTRIBUTING-NIX.md](CONTRIBUTING-NIX.md).
 
 ## Setting Up Your Environment
 
-After forking to your own GitHub org or account, do the following steps to get started:
+After forking to your own GitHub organization or account, take the following steps to get started:
 
 ```bash
 # prerequisites
@@ -57,7 +57,7 @@ pnpm run dev:android
 This codebase's linting rules are enforced using [ESLint](http://eslint.org/).
 
 It is recommended that you install an eslint plugin for your editor of choice when working on this
-codebase, however you can always check to see if the source code is compliant by running:
+codebase, however, you can always check to see if the source code is compliant by running:
 
 ```bash
 pnpm run lint


### PR DESCRIPTION
## Description
This PR fixes sentence trailing periods, organization name expansion, and introductory comma formatting in `CONTRIBUTING.md`.

## Details
1. Added missing period (`See CONTRIBUTING-NIX.md` $\to$ `See CONTRIBUTING-NIX.md.`).
2. Expanded abbreviation (`GitHub org` $\to$ `GitHub organization`).
3. Added missing introductory comma after `however`.