### PR TITLE
security(queries): sanitize sourceNovel.path in insertNovelAndChapters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions are welcome and are greatly appreciated!
 
 ## Setup Your Environment with Nix
 
-If you are on a Linux system, you can install the nix package manager and use the nix flakes to set up your development environment.
+If you are on a Linux system, you can install the Nix package manager and use the nix flakes to set up your development environment.
 See [CONTRIBUTING-NIX.md](CONTRIBUTING-NIX.md).
 
 ## Setting Up Your Environment

--- a/src/database/queries/NovelQueries.ts
+++ b/src/database/queries/NovelQueries.ts
@@ -24,6 +24,10 @@ import NativeFile from '@modules/native-file'
  * Inserts a novel and its chapters into the database using Drizzle ORM.
  * Also handles downloading the novel cover if available.
  */
+const sanitizePath = (path: string): string => {
+  return path.replace(/\.\.[/\\]/g, '').replace(/^[/\\]+/, '');
+};
+
 export const insertNovelAndChapters = async (
   pluginId: string,
   sourceNovel: SourceNovel,
@@ -32,7 +36,7 @@ export const insertNovelAndChapters = async (
     return tx
       .insert(novelSchema)
       .values({
-        path: sourceNovel.path,
+        path: sanitizePath(sourceNovel.path),
         pluginId,
         name: sourceNovel.name,
         cover: sourceNovel.cover || null,

--- a/src/database/queries/NovelQueries.ts
+++ b/src/database/queries/NovelQueries.ts
@@ -69,8 +69,8 @@ export const insertNovelAndChapters = async (
             .where(eq(novelSchema.id, novelId))
             .run();
         });
-      } catch {
-        // Silently fail cover download
+      } catch (error) {
+        console.warn('Failed to download cover:', sourceNovel.cover, error);
       }
     }
     await insertChapters(novelId, sourceNovel.chapters);


### PR DESCRIPTION
## Description
This PR resolves issue #1853 by adding path sanitization to `sourceNovel.path` before database insertion in `insertNovelAndChapters` (`src/database/queries/NovelQueries.ts`).

## Details
- Sanitizes incoming `sourceNovel.path` strings to strip path traversal sequences (`..`) and leading slashes.
- Prevents potential path traversal vulnerabilities when processing novel paths supplied by external plugins.