### PR TITLE
fix(reader): propagate error in loadChapterText to prevent caching empty string on failure

### DIFF
--- a/src/screens/reader/hooks/useChapter.ts
+++ b/src/screens/reader/hooks/useChapter.ts
@@ -116,11 +116,7 @@ export default function useChapter(
       if (await NativeFile.exists(filePath)) {
         text = await NativeFile.readFile(filePath);
       } else {
-        await fetchChapter(novel.pluginId, path)
-          .then(res => {
-            text = res;
-          })
-          .catch(e => setError(e.message));
+        text = await fetchChapter(novel.pluginId, path);
       }
       return text;
     },


### PR DESCRIPTION
## Description
This PR resolves issue #1811 by permitting `loadChapterText` in `src/screens/reader/hooks/useChapter.ts` to propagate network errors during chapter fetching rather than swallowing them and returning an empty string.

## Details
- Previously, when `fetchChapter` encountered an error (such as a Cloudflare challenge or timeout), `loadChapterText` caught the exception and returned an empty string `''`.
- As a result, the empty string was cached in `chapterTextCache`, preventing subsequent "Retry" attempts from making network requests.
- Allowing `fetchChapter` to throw ensures the error is handled by the outer `try...catch` block and prevents corrupting `chapterTextCache` with empty text.