### PR TITLE
security(queries): warn and skip insecure HTTP cover downloads in insertNovelAndChapters

### DIFF
--- a/src/database/queries/NovelQueries.ts
+++ b/src/database/queries/NovelQueries.ts
@@ -52,7 +52,10 @@ export const insertNovelAndChapters = async (
 
   if (novelId) {
     if (sourceNovel.cover) {
-      const novelDir = NOVEL_STORAGE + '/' + pluginId + '/' + novelId;
+      if (sourceNovel.cover.startsWith('http://')) {
+        console.warn('Skipping insecure HTTP cover download:', sourceNovel.cover);
+      } else {
+        const novelDir = NOVEL_STORAGE + '/' + pluginId + '/' + novelId;
       await NativeFile.mkdir(novelDir);
       const novelCoverPath = novelDir + '/cover.png';
       const novelCoverUri = 'file://' + novelCoverPath;
@@ -71,6 +74,7 @@ export const insertNovelAndChapters = async (
         });
       } catch {
         // Silently fail cover download
+      }
       }
     }
     await insertChapters(novelId, sourceNovel.chapters);


### PR DESCRIPTION
## Description
This PR resolves issue #1854 by skipping unencrypted HTTP cover URL downloads in `insertNovelAndChapters` (`src/database/queries/NovelQueries.ts`).

## Details
- Inspects `sourceNovel.cover` before initiating cover downloads.
- If the cover URL uses unencrypted `http://`, it outputs a warning via `console.warn` and skips downloading to prevent plain-text MITM vectors on user devices.