### PR TITLE
fix(database): log cover download errors with console.warn in insertNovelAndChapters

### DIFF
--- a/src/database/queries/NovelQueries.ts
+++ b/src/database/queries/NovelQueries.ts
@@ -69,8 +69,8 @@ export const insertNovelAndChapters = async (
             .where(eq(novelSchema.id, novelId))
             .run();
         });
-      } catch {
-        // Silently fail cover download
+      } catch (error) {
+        console.warn('Failed to download cover:', sourceNovel.cover, error);
       }
     }
     await insertChapters(novelId, sourceNovel.chapters);


### PR DESCRIPTION
## Description
This PR resolves issue #1855 by logging cover download errors with `console.warn` in `insertNovelAndChapters` (`src/database/queries/NovelQueries.ts`).

## Details
- Replaces silent `catch` block swallowing with explicit `console.warn` logging.
- Preserves non-blocking novel insertion while surfacing cover download failures for debugging and security auditing.