### PR TITLE
fix(reader): allow currentPage equal to totalPages in useChapter next page prefetch

### DIFF
--- a/src/screens/reader/hooks/useChapter.ts
+++ b/src/screens/reader/hooks/useChapter.ts
@@ -162,7 +162,7 @@ export default function useChapter(
 
         // Pre-fetch adjacent page chapters if at a page boundary
         const currentPage = Number(chap.page);
-        if (!nextChap && totalPages > 0 && currentPage < totalPages) {
+        if (!nextChap && totalPages > 0 && currentPage <= totalPages) {
           const nextPage = String(currentPage + 1);
           try {
             const count = await getChapterCount(chap.novelId, nextPage);


### PR DESCRIPTION
## Description
This PR resolves issue #1816 by updating the totalPages boundary check in `useChapter.ts` (`src/screens/reader/hooks/useChapter.ts`).

## Details
- Previously, `currentPage < totalPages` strictly excluded boundary cases where `currentPage === totalPages`.
- Updating the condition to `currentPage <= totalPages` ensures adjacent chapter prefetching and rendering includes the final page without prematurely jumping chapters.