### PR TITLE
fix(queries): split and deduplicate comma-separated scanlator strings in getNovelScanlators

### DIFF
--- a/src/database/queries/ChapterQueries.ts
+++ b/src/database/queries/ChapterQueries.ts
@@ -841,7 +841,9 @@ export const getNovelScanlators = async (
       ),
     )
     .all();
-  return result.map(r => r.scanlator).filter(Boolean) as string[];
+  const rawList = result.map(r => r.scanlator).filter(Boolean) as string[];
+  const individual = rawList.flatMap(s => s.split(',').map(item => item.trim())).filter(Boolean);
+  return Array.from(new Set(individual));
 };
 
 export const getNovelScanlatorsSync = (novelId: number): string[] => {
@@ -857,5 +859,7 @@ export const getNovelScanlatorsSync = (novelId: number): string[] => {
         ),
       ),
   );
-  return result.map(r => r.scanlator).filter(Boolean) as string[];
+  const rawList = result.map(r => r.scanlator).filter(Boolean) as string[];
+  const individual = rawList.flatMap(s => s.split(',').map(item => item.trim())).filter(Boolean);
+  return Array.from(new Set(individual));
 };


### PR DESCRIPTION
## Description
This PR resolves issue #1794 by parsing individual comma-separated scanlator team strings in `getNovelScanlators` and `getNovelScanlatorsSync` (`src/database/queries/ChapterQueries.ts`).

## Details
- Previously, `selectDistinct` returned joined comma-separated scanlator strings (e.g. `'Team A, Team B'`), causing translator team filter UI components to overflow and overlap.
- Updates query functions to split comma-separated strings and return a Set of unique individual translator group names.