### PR TITLE
fix(updates): log library update errors with console.warn in updateNovel

### DIFF
--- a/src/services/updates/LibraryUpdateQueries.ts
+++ b/src/services/updates/LibraryUpdateQueries.ts
@@ -222,25 +222,27 @@ const updateNovel = async (
             sourcePage.chapters || [],
             downloadNewChapters,
             String(oldTotalPages),
-            enqueue,
-          );
-        } catch {}
-      }
+          } catch (err) {
+            console.warn(`Failed to update re-fetched page ${oldTotalPages} for '${novel.name}':`, err);
+          }
+        }
 
-      // Fetch any new pages that were added
-      for (let page = oldTotalPages + 1; page <= novel.totalPages; page++) {
-        try {
-          const sourcePage = await fetchPage(pluginId, novelPath, String(page));
-          await updateNovelChapters(
-            novel.name,
-            novelId,
-            sourcePage.chapters || [],
-            downloadNewChapters,
-            String(page),
-            enqueue,
-          );
-        } catch {}
-      }
+        // Fetch any new pages that were added
+        for (let page = oldTotalPages + 1; page <= novel.totalPages; page++) {
+          try {
+            const sourcePage = await fetchPage(pluginId, novelPath, String(page));
+            await updateNovelChapters(
+              novel.name,
+              novelId,
+              sourcePage.chapters || [],
+              downloadNewChapters,
+              String(page),
+              enqueue,
+            );
+          } catch (err) {
+            console.warn(`Failed to fetch page ${page} for '${novel.name}':`, err);
+          }
+        }
     }
   }
 };


### PR DESCRIPTION
## Description
This PR resolves issue #1822 by logging background library update errors with `console.warn` in `LibraryUpdateQueries.ts`.

## Details
- Replaces empty `catch {}` blocks during page refetching in `updateNovel` with explicit `console.warn` calls.
- Provides diagnostic visibility into update failures without interrupting the user with intrusive toast notifications.