### PR TITLE
fix(updates): guard new page iteration bounds in updateNovel

### DIFF
--- a/src/services/updates/LibraryUpdateQueries.ts
+++ b/src/services/updates/LibraryUpdateQueries.ts
@@ -227,20 +227,24 @@ const updateNovel = async (
         } catch {}
       }
 
-      // Fetch any new pages that were added
-      for (let page = oldTotalPages + 1; page <= novel.totalPages; page++) {
-        try {
-          const sourcePage = await fetchPage(pluginId, novelPath, String(page));
-          await updateNovelChapters(
-            novel.name,
-            novelId,
-            sourcePage.chapters || [],
-            downloadNewChapters,
-            String(page),
-            enqueue,
-          );
-        } catch {}
-      }
+        // Fetch any new pages that were added
+        if (oldTotalPages > 0 && oldTotalPages <= novel.totalPages) {
+          for (let page = oldTotalPages + 1; page <= novel.totalPages; page++) {
+            try {
+              const sourcePage = await fetchPage(pluginId, novelPath, String(page));
+              await updateNovelChapters(
+                novel.name,
+                novelId,
+                sourcePage.chapters || [],
+                downloadNewChapters,
+                String(page),
+                enqueue,
+              );
+            } catch (err) {
+              console.warn(`Failed to fetch page ${page} for '${novel.name}':`, err);
+            }
+          }
+        }
     }
   }
 };


### PR DESCRIPTION
## Description
This PR resolves issue #1856 by guarding page iteration bounds in `updateNovel` (`src/services/updates/LibraryUpdateQueries.ts`).

## Details
- Adds a sanity guard (`oldTotalPages > 0 && oldTotalPages <= novel.totalPages`) before attempting page iteration during library updates.
- Prevents invalid loops or page fetching errors when updating novels with reverse/DESC page plugins or fluctuating page counts.