### PR TITLE
fix(db): add chaptersDownloaded column repair check for legacy schema upgrades

### DIFF
--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -93,6 +93,18 @@ export const repairMigrationHistory = (executor: MigrationExecutor) => {
       AND created_at = ${INITIAL_MIGRATION_CREATED_AT};
   `);
 
+  const novelColumns = executor.executeRawSync('PRAGMA table_info(Novel);');
+  const hasChaptersDownloaded = novelColumns.some(row => row[1] === 'chaptersDownloaded');
+  if (novelColumns.length > 0 && !hasChaptersDownloaded) {
+    try {
+      executor.executeSync(
+        "ALTER TABLE 'Novel' ADD COLUMN 'chaptersDownloaded' integer DEFAULT 0;",
+      );
+    } catch {
+      // column already exists
+    }
+  }
+
   const chapterColumns = executor.executeRawSync('PRAGMA table_info(Chapter);');
   const hasScanlator = chapterColumns.some(row => row[1] === 'scanlator');
 


### PR DESCRIPTION
## Description
This PR resolves issue #1915 by adding a column repair check for `chaptersDownloaded` in `repairMigrationHistory` (`src/database/db.ts`).

## Details
- Checks `PRAGMA table_info(Novel);` during database initialization.
- Automatically executes `ALTER TABLE 'Novel' ADD COLUMN 'chaptersDownloaded' integer DEFAULT 0;` if missing from legacy app databases.