### PR TITLE
fix(updates): log page fetch failures with console.warn in updateNovel

### DIFF
--- a/src/services/updates/LibraryUpdateQueries.ts
+++ b/src/services/updates/LibraryUpdateQueries.ts
@@ -239,7 +239,9 @@ const updateNovel = async (
             String(page),
             enqueue,
           );
-        } catch {}
+        } catch (err) {
+          console.warn(`[LibraryUpdate] Failed to fetch page ${page} for novel ${novelName}:`, err);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
This PR resolves issue #1856 by logging page fetch failures with `console.warn` during background novel updates in `LibraryUpdateQueries.ts`.

## Details
- Replaces empty catch blocks with informative `console.warn` logging when page iteration fails during multi-page chapter updates.