### PR TITLE
fix(novel): pass plugin imageRequestInit headers to detail cover

### DIFF
--- a/src/screens/novel/components/Info/NovelInfoHeader.tsx
+++ b/src/screens/novel/components/Info/NovelInfoHeader.tsx
@@ -32,6 +32,7 @@ import { NovelStatus, PluginItem } from '@plugins/types';
 import { translateNovelStatus } from '@utils/translateEnum';
 import { getMMKVObject } from '@utils/mmkv/mmkv';
 import { AVAILABLE_PLUGINS } from '@hooks/persisted/usePlugins';
+import { getPlugin } from '@plugins/pluginManager';
 
 import {
   NovelMetaSkeleton,
@@ -112,10 +113,13 @@ const NovelInfoHeader = ({
     [novel.pluginId],
   );
 
-  const coverSource = useMemo(
-    () => ({ uri: novel.cover ?? undefined }),
-    [novel.cover],
-  );
+  const coverSource = useMemo(() => {
+    const imageRequestInit = getPlugin(novel.pluginId)?.imageRequestInit;
+    return {
+      uri: novel.cover ?? undefined,
+      headers: imageRequestInit?.headers,
+    };
+  }, [novel.pluginId, novel.cover]);
 
   const novelStatus = useMemo(
     () => (novel.id !== 'NO_ID' ? novel.status ?? undefined : undefined),


### PR DESCRIPTION
The novel detail header rendered its cover with a bare { uri } source, so plugins whose cover CDN requires request headers (e.g. RanobeLib's cover.cdnlibs.org, which 403s without a Referer) showed no cover on the novel detail screen even though covers worked in browse/library lists.

Mirror the LibraryListView pattern: fetch getPlugin(novel.pluginId)? .imageRequestInit and attach its headers to the cover source.