### PR TITLE
feat: make WebView address bar editable

### DIFF
--- a/src/i18n/languages/en/strings.json
+++ b/src/i18n/languages/en/strings.json
@@ -359,7 +359,8 @@
     "clearCookies": "Clear cookies",
     "cookiesCleared": "Cookies cleared",
     "clearData": "Clear WebView data",
-    "dataDeleted": "WebView data cleared"
+    "dataDeleted": "WebView data cleared",
+    "enterUrl": "Enter address"
   },
   "date": {
     "calendar": {

--- a/src/i18n/types/index.ts
+++ b/src/i18n/types/index.ts
@@ -315,6 +315,7 @@ export interface StringMap {
   'webview.cookiesCleared': 'string';
   'webview.clearData': 'string';
   'webview.dataDeleted': 'string';
+  'webview.enterUrl': 'string';
   'date.calendar.lastDay': 'string';
   'date.calendar.lastWeek': 'string';
   'date.calendar.nextDay': 'string';

--- a/src/screens/WebviewScreen/WebviewScreen.tsx
+++ b/src/screens/WebviewScreen/WebviewScreen.tsx
@@ -92,8 +92,32 @@ const WebviewScreen = ({ route, navigation }: WebviewScreenProps) => {
   const injectJavaScriptCode =
     'window.ReactNativeWebView.postMessage(JSON.stringify({localStorage, sessionStorage}))';
 
-  // A new `source` reloads the page, so keep it stable across progress updates.
-  const source = useMemo(() => ({ uri }), [uri]);
+  // A new `source` reloads the page, so keep it stable across progress updates
+  // and only replace it when the route or the address bar asks for a new page.
+  const [source, setSource] = useState(() => ({ uri }));
+  const [routeUri, setRouteUri] = useState(uri);
+  if (routeUri !== uri) {
+    setRouteUri(uri);
+    setSource({ uri });
+  }
+
+  const navigateTo = useCallback(
+    (target: string) => {
+      if (source.uri !== target) {
+        setSource({ uri: target });
+        setCurrentUrl(target);
+      } else if (target === currentUrl) {
+        webViewRef.current?.reload();
+      } else {
+        // `source` already holds this address, so a new prop would be diffed
+        // away before reaching the native side; navigate from inside the page.
+        webViewRef.current?.injectJavaScript(
+          `window.location.href = ${JSON.stringify(target)}; true;`,
+        );
+      }
+    },
+    [currentUrl, source.uri],
+  );
 
   return (
     <>
@@ -105,6 +129,7 @@ const WebviewScreen = ({ route, navigation }: WebviewScreenProps) => {
         canGoForward={canGoForward}
         webView={webViewRef}
         setMenuVisible={setMenuVisible}
+        navigateTo={navigateTo}
         goBack={() => {
           saveData();
           navigation.goBack();

--- a/src/screens/WebviewScreen/components/Appbar.tsx
+++ b/src/screens/WebviewScreen/components/Appbar.tsx
@@ -1,8 +1,16 @@
-import React, { RefObject } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { RefObject, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  Keyboard,
+  StyleSheet,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { IconButtonV2 } from '@components';
+import { getString } from '@i18n/translations';
 import { ThemeColors } from '@theme/types';
 import WebView from 'react-native-webview';
 
@@ -15,7 +23,21 @@ interface AppbarProps {
   webView: RefObject<WebView<object> | null>;
   setMenuVisible: (value: boolean) => void;
   goBack: () => void;
+  navigateTo: (url: string) => void;
 }
+
+/**
+ * Turns whatever was typed into something the WebView can load. Anything that
+ * already carries a scheme is left alone, everything else is assumed to be
+ * https.
+ */
+const normalizeUrl = (input: string) => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return /^[a-z][a-z0-9+.-]*:/i.test(trimmed) ? trimmed : `https://${trimmed}`;
+};
 
 const Appbar: React.FC<AppbarProps> = ({
   title,
@@ -26,8 +48,33 @@ const Appbar: React.FC<AppbarProps> = ({
   webView,
   setMenuVisible,
   goBack,
+  navigateTo,
 }) => {
   const { top } = useSafeAreaInsets();
+
+  const [editing, setEditing] = useState(false);
+  // Seeded when editing starts so in-page navigations can't overwrite what the
+  // user is typing.
+  const [draft, setDraft] = useState(currentUrl);
+
+  const startEditing = () => {
+    setDraft(currentUrl);
+    setEditing(true);
+  };
+
+  const stopEditing = () => {
+    setEditing(false);
+    Keyboard.dismiss();
+  };
+
+  const submit = () => {
+    const url = normalizeUrl(draft);
+    setEditing(false);
+    Keyboard.dismiss();
+    if (url) {
+      navigateTo(url);
+    }
+  };
 
   return (
     <View
@@ -37,51 +84,98 @@ const Appbar: React.FC<AppbarProps> = ({
       ]}
     >
       <View style={styles.appbar}>
-        <IconButtonV2
-          name="close"
-          color={theme.onSurface}
-          onPress={goBack}
-          padding={12}
-          theme={theme}
-        />
-        <View style={styles.titleContainer}>
-          <Text
-            numberOfLines={1}
-            style={[styles.title, { color: theme.onSurface }]}
-          >
-            {title}
-          </Text>
-          <Text
-            numberOfLines={1}
-            style={[styles.url, { color: theme.onSurfaceVariant }]}
-          >
-            {currentUrl}
-          </Text>
-        </View>
-        <View style={styles.iconContainer}>
+        {editing ? (
+          // `onPressIn`, because blurring the address input unmounts this
+          // button before a plain `onPress` would ever fire.
           <IconButtonV2
             name="arrow-left"
             color={theme.onSurface}
-            disabled={!canGoBack}
-            onPress={() => webView.current?.goBack()}
+            onPressIn={stopEditing}
             padding={12}
             theme={theme}
           />
+        ) : (
           <IconButtonV2
-            name="arrow-right"
+            name="close"
             color={theme.onSurface}
-            disabled={!canGoForward}
-            onPress={() => webView.current?.goForward()}
+            onPress={goBack}
             padding={12}
             theme={theme}
           />
-          <IconButtonV2
-            name="dots-vertical"
-            color={theme.onSurface}
-            onPress={() => setMenuVisible(true)}
-            padding={12}
-            theme={theme}
+        )}
+        {editing ? (
+          <TextInput
+            value={draft}
+            onChangeText={setDraft}
+            onSubmitEditing={submit}
+            onBlur={stopEditing}
+            autoFocus
+            selectTextOnFocus
+            autoCapitalize="none"
+            autoCorrect={false}
+            autoComplete="off"
+            spellCheck={false}
+            keyboardType="url"
+            returnKeyType="go"
+            placeholder={getString('webview.enterUrl')}
+            placeholderTextColor={theme.onSurfaceVariant}
+            style={[
+              styles.input,
+              { color: theme.onSurface, backgroundColor: theme.surface2 },
+            ]}
           />
+        ) : (
+          <Pressable style={styles.titleContainer} onPress={startEditing}>
+            <Text
+              numberOfLines={1}
+              style={[styles.title, { color: theme.onSurface }]}
+            >
+              {title}
+            </Text>
+            <Text
+              numberOfLines={1}
+              style={[styles.url, { color: theme.onSurfaceVariant }]}
+            >
+              {currentUrl}
+            </Text>
+          </Pressable>
+        )}
+        <View style={styles.iconContainer}>
+          {editing ? (
+            <IconButtonV2
+              name="arrow-right"
+              color={theme.onSurface}
+              onPressIn={submit}
+              padding={12}
+              theme={theme}
+            />
+          ) : (
+            <>
+              <IconButtonV2
+                name="arrow-left"
+                color={theme.onSurface}
+                disabled={!canGoBack}
+                onPress={() => webView.current?.goBack()}
+                padding={12}
+                theme={theme}
+              />
+              <IconButtonV2
+                name="arrow-right"
+                color={theme.onSurface}
+                disabled={!canGoForward}
+                onPress={() => webView.current?.goForward()}
+                padding={12}
+                theme={theme}
+              />
+              <IconButtonV2
+                name="dots-vertical"
+                color={theme.onSurface}
+                onPress={() => setMenuVisible(true)}
+                padding={12}
+                theme={theme}
+              />
+            </>
+          )}
         </View>
       </View>
     </View>
@@ -104,6 +198,15 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'flex-end',
     marginLeft: 4,
+  },
+  input: {
+    borderRadius: 20,
+    flex: 1,
+    fontSize: 16,
+    marginHorizontal: 4,
+    minWidth: 0,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
   },
   title: {
     fontSize: 18,


### PR DESCRIPTION
What changed

Makes the WebView address bar editable so users can manually enter and navigate to a URL.

The address bar continues to update automatically when the WebView navigates to another page.

Changes
Replace the displayed WebView URL with an editable input Allow navigation by pressing the keyboard's Go/Enter button Automatically prepend https:// when no protocol is provided Keep the address bar synchronized with WebView navigation Preserve existing back, forward, and reload controls

Testing
Opened the WebView and verified the current URL is displayed Navigated by entering a full https:// URL
Navigated using a URL without a protocol
Followed links inside the WebView and verified the address bar updates Verified back, forward, and reload continue to work

this need when site need login and send link  for login to email