### PR TITLE
fix(reader): give opaque WebView chapters a local origin (#1999)

### DIFF
--- a/src/screens/reader/components/WebViewReader.tsx
+++ b/src/screens/reader/components/WebViewReader.tsx
@@ -30,6 +30,7 @@ import { useTtsSession } from '../hooks/useTtsSession';
 import type { TtsSettings } from '@modules/nitro-tts';
 import { ChapterInfo } from '@database/types';
 import { Dialog } from '@components/Dialog';
+import { resolveBaseUrl } from './webViewSource';
 import { TextInput } from 'react-native-paper';
 import useCustomCode from './Hooks/useCustomCode';
 import useTextModifications from './Hooks/useTextModifications';
@@ -316,7 +317,10 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
     // eslint-disable-next-line react-hooks/refs
     const isNextChapterScreenVisible = nextChapterScreenVisible.current;
     return {
-      baseUrl: !chapter.isDownloaded ? plugin?.site : undefined,
+      baseUrl: resolveBaseUrl({
+        isDownloaded: chapter.isDownloaded,
+        pluginSite: plugin?.site,
+      }),
       headers: plugin?.imageRequestInit?.headers,
       method: plugin?.imageRequestInit?.method,
       body: plugin?.imageRequestInit?.body,
@@ -434,8 +438,8 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
     chapter,
     chapterGeneralSettings,
     processedHtml,
-      customJS,
-      customCSS,
+    customJS,
+    customCSS,
     initialReaderSettings,
     novel,
     plugin,
@@ -446,31 +450,31 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
   ]);
 
   return (
-      <>
-    <WebView
-      ref={webViewRef}
-      onTouchStart={onTouchStart}
-      style={{ backgroundColor: readerSettings.theme }}
-      allowFileAccess={true}
-      originWhitelist={['*']}
-      scalesPageToFit={true}
-      showsVerticalScrollIndicator={false}
-      javaScriptEnabled={true}
-      webviewDebuggingEnabled={__DEV__}
-      onShouldStartLoadWithRequest={({ url }) => {
-        if (isPluginIssueReportUrl(url)) {
-          void Linking.openURL(url);
-          return false;
-        }
-        if (isChapterRefreshUrl(url)) {
-          refetch();
-          return false;
-        }
-        return true;
-      }}
-      onLoadEnd={() => {
-        webViewRef.current?.injectJavaScript(
-          `if (window.reader && window.reader.batteryLevel) {
+    <>
+      <WebView
+        ref={webViewRef}
+        onTouchStart={onTouchStart}
+        style={{ backgroundColor: readerSettings.theme }}
+        allowFileAccess={true}
+        originWhitelist={['*']}
+        scalesPageToFit={true}
+        showsVerticalScrollIndicator={false}
+        javaScriptEnabled={true}
+        webviewDebuggingEnabled={__DEV__}
+        onShouldStartLoadWithRequest={({ url }) => {
+          if (isPluginIssueReportUrl(url)) {
+            void Linking.openURL(url);
+            return false;
+          }
+          if (isChapterRefreshUrl(url)) {
+            refetch();
+            return false;
+          }
+          return true;
+        }}
+        onLoadEnd={() => {
+          webViewRef.current?.injectJavaScript(
+            `if (window.reader && window.reader.batteryLevel) {
             window.reader.batteryLevel.val = ${lastKnownBatteryLevel};
           }`,
           );

--- a/src/screens/reader/components/__tests__/webViewSource.test.ts
+++ b/src/screens/reader/components/__tests__/webViewSource.test.ts
@@ -50,6 +50,19 @@ describe('resolveBaseUrl — fallback-only matrix (#1999)', () => {
       FALLBACK_BASE_URL,
     );
   });
+
+  it('null isDownloaded + site keeps the origin (null behaves as not-downloaded)', () => {
+    expect(resolveBaseUrl({ isDownloaded: null, pluginSite: SITE })).toBe(SITE);
+  });
+
+  it('null isDownloaded + no site falls back (never leaves the origin opaque)', () => {
+    expect(resolveBaseUrl({ isDownloaded: null, pluginSite: undefined })).toBe(
+      FALLBACK_BASE_URL,
+    );
+    expect(resolveBaseUrl({ isDownloaded: null, pluginSite: '' })).toBe(
+      FALLBACK_BASE_URL,
+    );
+  });
 });
 
 describe('AC2 — absolute asset URIs independent of baseUrl (#1999)', () => {

--- a/src/screens/reader/components/__tests__/webViewSource.test.ts
+++ b/src/screens/reader/components/__tests__/webViewSource.test.ts
@@ -72,16 +72,27 @@ describe('AC2 — absolute asset URIs independent of baseUrl (#1999)', () => {
   );
 
   it.each([
-    ['online + site', { isDownloaded: false, pluginSite: SITE }],
-    ['downloaded', { isDownloaded: true, pluginSite: undefined }],
-    ['online site-less', { isDownloaded: false, pluginSite: undefined }],
-  ])('%s: asset URIs stay absolute file:///android_asset', (_label, cohort) => {
-    // Whatever origin this cohort gets, the template must keep absolute
-    // asset URIs — assert the resolver result AND the template contract.
-    const baseUrl = resolveBaseUrl(cohort);
-    expect(typeof baseUrl === 'string' || baseUrl === undefined).toBe(true);
+    ['online + site', { isDownloaded: false, pluginSite: SITE }, SITE] as const,
+    [
+      'downloaded',
+      { isDownloaded: true, pluginSite: undefined },
+      FALLBACK_BASE_URL,
+    ] as const,
+    [
+      'online site-less',
+      { isDownloaded: false, pluginSite: undefined },
+      FALLBACK_BASE_URL,
+    ] as const,
+  ])(
+    '%s: asset URIs stay absolute file:///android_asset',
+    (_label, cohort, expectedBaseUrl) => {
+      // Pin the exact expected origin for this cohort — a real assertion that
+      // fails if resolveBaseUrl drifts — then assert the template contract:
+      // the asset references must never depend on baseUrl.
+      expect(resolveBaseUrl(cohort)).toBe(expectedBaseUrl);
 
-    expect(readerSource).toContain("'file:///android_asset'");
-    expect(readerSource).toMatch(/file:\/\/\/android_asset\/fonts\/\$\{/);
-  });
+      expect(readerSource).toContain("'file:///android_asset'");
+      expect(readerSource).toMatch(/file:\/\/\/android_asset\/fonts\/\$\{/);
+    },
+  );
 });

--- a/src/screens/reader/components/__tests__/webViewSource.test.ts
+++ b/src/screens/reader/components/__tests__/webViewSource.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Red-first matrix test for the WebView baseUrl contract (#1999, ruling
+ * 59414f8: fallback-only).
+ *
+ * The baseUrl decision lives inline in WebViewReader's `source` useMemo.
+ * To test it without rendering the whole reader, extract the same
+ * expression into a tiny exported helper (resolveBaseUrl) and have the
+ * component consume it — the helper IS the production logic, so these
+ * tests pin the real behavior:
+ *
+ *   online + plugin.site   → plugin.site   (working path, byte-stable)
+ *   downloaded             → 'https://lnreader.local/'  (opaque cohort A)
+ *   online, no plugin.site → 'https://lnreader.local/'  (opaque cohort B)
+ *
+ * AC2 additionally pins that generated HTML keeps ABSOLUTE
+ * file:///android_asset asset URIs in all three cohorts: the template's
+ * asset references do not depend on baseUrl, so a changed origin can never
+ * break fonts/images. The assertion reads WebViewReader.tsx source and
+ * fails if anyone converts those URIs to relative paths.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { resolveBaseUrl, FALLBACK_BASE_URL } from '../webViewSource';
+
+const SITE = 'https://some-plugin.example.com';
+
+describe('resolveBaseUrl — fallback-only matrix (#1999)', () => {
+  it('keeps plugin.site for online chapters with a site (byte-stable working path)', () => {
+    expect(resolveBaseUrl({ isDownloaded: false, pluginSite: SITE })).toBe(
+      SITE,
+    );
+  });
+
+  it('fills downloaded chapters with https://lnreader.local/', () => {
+    expect(resolveBaseUrl({ isDownloaded: true, pluginSite: SITE })).toBe(
+      FALLBACK_BASE_URL,
+    );
+    expect(resolveBaseUrl({ isDownloaded: true, pluginSite: undefined })).toBe(
+      FALLBACK_BASE_URL,
+    );
+  });
+
+  it('fills online chapters whose plugin has no site with https://lnreader.local/', () => {
+    expect(resolveBaseUrl({ isDownloaded: false, pluginSite: undefined })).toBe(
+      FALLBACK_BASE_URL,
+    );
+    expect(resolveBaseUrl({ isDownloaded: false, pluginSite: '' })).toBe(
+      FALLBACK_BASE_URL,
+    );
+  });
+});
+
+describe('AC2 — absolute asset URIs independent of baseUrl (#1999)', () => {
+  const readerSource = readFileSync(
+    join(process.cwd(), 'src/screens/reader/components/WebViewReader.tsx'),
+    'utf8',
+  );
+
+  it.each([
+    ['online + site', { isDownloaded: false, pluginSite: SITE }],
+    ['downloaded', { isDownloaded: true, pluginSite: undefined }],
+    ['online site-less', { isDownloaded: false, pluginSite: undefined }],
+  ])('%s: asset URIs stay absolute file:///android_asset', (_label, cohort) => {
+    // Whatever origin this cohort gets, the template must keep absolute
+    // asset URIs — assert the resolver result AND the template contract.
+    const baseUrl = resolveBaseUrl(cohort);
+    expect(typeof baseUrl === 'string' || baseUrl === undefined).toBe(true);
+
+    expect(readerSource).toContain("'file:///android_asset'");
+    expect(readerSource).toMatch(/file:\/\/\/android_asset\/fonts\/\$\{/);
+  });
+});

--- a/src/screens/reader/components/webViewSource.ts
+++ b/src/screens/reader/components/webViewSource.ts
@@ -20,12 +20,13 @@ export const resolveBaseUrl = ({
 }): string | undefined => {
   // A null/unset flag behaves like "not downloaded" for origin purposes:
   // only a positively-downloaded chapter with no site falls back, and an
-  // online chapter needs a positively-present site to keep it.
+  // online chapter needs a positively-present site to keep it. Every other
+  // path lands on the fallback — the origin is never left opaque.
   if (!isDownloaded && pluginSite) {
     return pluginSite;
   }
   if (isDownloaded) {
     return FALLBACK_BASE_URL;
   }
-  return pluginSite ? undefined : FALLBACK_BASE_URL;
+  return FALLBACK_BASE_URL;
 };

--- a/src/screens/reader/components/webViewSource.ts
+++ b/src/screens/reader/components/webViewSource.ts
@@ -1,0 +1,31 @@
+/**
+ * WebView source helpers (#1999, ruling 59414f8: fallback-only baseUrl).
+ *
+ * resolveBaseUrl encodes the entire baseUrl matrix for the reader WebView:
+ * online chapters with a plugin site keep their real origin (working path
+ * — byte-stable, CORS/relative-link semantics untouched); the two opaque
+ * cohorts (downloaded chapters, site-less plugins) get a fixed local origin
+ * so storage/clipboard APIs and null-Origin quirks stop breaking.
+ */
+
+export const FALLBACK_BASE_URL = 'https://lnreader.local/';
+
+export const resolveBaseUrl = ({
+  isDownloaded,
+  pluginSite,
+}: {
+  /** Chapter.isDownloaded is `boolean | null` at the DB layer. */
+  isDownloaded: boolean | null | undefined;
+  pluginSite?: string;
+}): string | undefined => {
+  // A null/unset flag behaves like "not downloaded" for origin purposes:
+  // only a positively-downloaded chapter with no site falls back, and an
+  // online chapter needs a positively-present site to keep it.
+  if (!isDownloaded && pluginSite) {
+    return pluginSite;
+  }
+  if (isDownloaded) {
+    return FALLBACK_BASE_URL;
+  }
+  return pluginSite ? undefined : FALLBACK_BASE_URL;
+};


### PR DESCRIPTION
# fix(reader): give opaque WebView chapters a local origin (#1999)

## What this does

Chapters read inside the app's WebView now get a proper web origin. Online
chapters from plugins that declare a website keep using that site exactly
as before — that path is untouched, byte for byte. The two cases that
previously had **no origin at all** (downloaded chapters, and online
chapters from plugins without a website) now get a fixed local origin,
`https://lnreader.local/`, so browser features that require a secure
context (like `localStorage`) stop failing in custom scripts and themes.

Implements the fallback-only origin ruling from issue #1999.

## How it works

- The origin decision moved into one tiny helper (`resolveBaseUrl`):
  - online chapter + plugin has a site → the plugin's site (unchanged)
  - downloaded chapter → `https://lnreader.local/`
  - online chapter, plugin site-less → `https://lnreader.local/`
- Assets (fonts, images) are referenced with absolute
  `file:///android_asset/...` URIs in the generated HTML regardless of
  origin, so changing the base URL cannot break them.
- Relative links inside chapters remain relative to whatever origin is
  active; plugins whose content relies on site-relative URLs should keep
  declaring their `site`. Handling genuinely site-less plugins' relative
  URLs stays a plugin-authoring concern — this change does not attempt to
  rewrite chapter content.

## Verification

- `pnpm run test:rn`: **81/81 suites, 390/390 tests PASS** at tip.
- `tsc --noEmit` exit 0.
- New matrix test pins all three cohorts; a second test asserts the
  generated HTML keeps absolute asset URIs in all three cohorts.

## Notes

- **Trackers are untouched** by this feature.
- **AI attribution:** generated with Hermes (builder-bob agent), reviewed by
  a human; `Co-authored-by: Hermes builder-bob <builder-bob@hermes.local>`
  on every commit.
- Base: upstream tip `cb1a5d9e` (v2.1.3); branch
  `fix/1999-webview-baseurl`, commit `7f3cfb87`.
