### PR TITLE
refactor(reader): typed WebView bridge modules with parity tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ release-artifacts/
 !plugins/android/
 ios/
 !modules/**/ios/
+
+# graphify tooling output
+graphify-out/

--- a/src/database/__tests__/db.test.ts
+++ b/src/database/__tests__/db.test.ts
@@ -204,7 +204,8 @@ const createExecutor = (sqlite: DB) => ({
 
 describe('new database initialization', () => {
   it('creates schema, triggers, and default data', async () => {
-    const sqlite = open({ name: ':memory:' });
+    // location ':memory:' is required on Windows — see testDb.ts note
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
     try {
@@ -252,7 +253,7 @@ describe('new database initialization', () => {
 
 describe('runDatabaseBootstrap', () => {
   it('applies pragmas, triggers, and default categories', () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
     try {
@@ -293,7 +294,7 @@ describe('runDatabaseBootstrap', () => {
 
 describe('production migrations', () => {
   it('rebuilds novel counters with one scan of the Chapter snapshot', () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     try {
       createSchema(sqlite);
 
@@ -330,7 +331,7 @@ describe('production migrations', () => {
   });
 
   it('can run after test schema exists', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
     try {
@@ -427,7 +428,7 @@ describe('production migrations', () => {
   });
 
   it('repairs a legacy Novel table that is missing counter columns', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
     try {
@@ -515,7 +516,7 @@ describe('production migrations', () => {
   });
 
   it('resumes after Novel was dropped during the previous repair migration', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
     try {
@@ -613,7 +614,7 @@ describe('production migrations', () => {
   });
 
   it('repairs an interrupted Chapter snapshot missing recent columns', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
     try {
@@ -704,7 +705,7 @@ describe('production migrations', () => {
   });
 
   it('preserves snapshot columns while adding a missing timeSpent column', () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     try {
       createSchema(sqlite);
       sqlite.executeSync('ALTER TABLE Chapter ADD scanlator text');
@@ -733,7 +734,7 @@ describe('production migrations', () => {
   });
 
   it('recovers when Chapter columns exist without migration records', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
     try {
@@ -819,7 +820,7 @@ describe('production migrations', () => {
   };
 
   it('recovers when novels were added while the migration was interrupted', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     sqlite.executeSync('PRAGMA foreign_keys = ON');
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
@@ -886,7 +887,7 @@ describe('production migrations', () => {
   });
 
   it('preserves novels added while the migration was interrupted (no legacy FK)', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
     try {
@@ -940,7 +941,7 @@ describe('production migrations', () => {
   });
 
   it('recovers when NovelCategory rows were added while the migration was interrupted', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     sqlite.executeSync('PRAGMA foreign_keys = ON');
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
@@ -998,7 +999,7 @@ describe('production migrations', () => {
   });
 
   it('unsticks a device whose previous attempt already crashed the migration', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     sqlite.executeSync('PRAGMA foreign_keys = ON');
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;
@@ -1103,7 +1104,7 @@ describe('production migrations', () => {
   });
 
   it('runs the full production initialization on a legacy database', async () => {
-    const sqlite = open({ name: ':memory:' });
+    const sqlite = open({ name: ':memory:', location: ':memory:' });
     sqlite.executeSync('PRAGMA foreign_keys = ON');
     (sqlite as any).executeAsync ??= sqlite.execute;
     (sqlite as any).executeRawAsync ??= sqlite.executeRaw;

--- a/src/database/queries/__tests__/testDb.ts
+++ b/src/database/queries/__tests__/testDb.ts
@@ -90,7 +90,13 @@ const MIGRATION_STATEMENTS = [
  */
 export function createTestDb() {
   // Create in-memory database
-  const sqlite = open({ name: ':memory:' });
+  // op-sqlite's Node adapter (wrapping better-sqlite3) decides the in-memory
+  // sentinel via the `location` option; with no location it does
+  // path.join('./', name), which on Windows yields '.\:memory:' (illegal
+  // filename) => SqliteError "unable to open database file". POSIX normalizes
+  // './:memory:' back to ':memory:', so Linux/macOS CI never sees this. Pass
+  // location ':memory:' to keep the sentinel intact (op-sqlite 5f3a102, #381).
+  const sqlite = open({ name: ':memory:', location: ':memory:' });
   // drizzle-orm/op-sqlite expects executeAsync on the client
   (sqlite as any).executeAsync ??= sqlite.execute;
   (sqlite as any).executeRawAsync ??= sqlite.executeRaw;

--- a/src/screens/reader/ReaderScreen.tsx
+++ b/src/screens/reader/ReaderScreen.tsx
@@ -5,6 +5,7 @@ import ReaderAppbar from './components/ReaderAppbar';
 import ReaderFooter from './components/ReaderFooter';
 
 import WebViewReader from './components/WebViewReader';
+import { pageReaderMovePageScript } from './bridge/pageReader';
 import ReaderBottomSheetV2 from './components/ReaderBottomSheet/ReaderBottomSheet';
 import ChapterDrawer from './components/ChapterDrawer';
 import ChapterLoadingScreen from './ChapterLoadingScreen/ChapterLoadingScreen';
@@ -197,8 +198,8 @@ export const ChapterContent = ({
                 window.scrollTo({top:0,behavior:'smooth'})
               })()`
           : `(()=>{
-              window.pageReader?.movePage(0);
-            })()`,
+                ${pageReaderMovePageScript(0)}
+              })()`,
       );
     });
   }, [onUserInteraction, pageReader, webViewRef]);

--- a/src/screens/reader/bridge/__tests__/coreSurface.test.ts
+++ b/src/screens/reader/bridge/__tests__/coreSurface.test.ts
@@ -1,0 +1,360 @@
+/**
+ * core.js surface parity tests — the TS-side bridge scripts vs the REAL
+ * WebView assets.
+ *
+ * Paranoia, exactly: the bridge modules emit scripts for window.tts /
+ * window.reader / window.readerSearch. If the JS asset renames a method or
+ * drops a state slot, those scripts silently no-op on device — the #2009
+ * class of failure. These tests load the real assets/reader/js/core.js and
+ * assets/reader/js/search.js in a minimal DOM stub (the pattern proven by
+ * #1576's rsvpBridge.test.ts) and then:
+ *   1. pin the surfaces the TS bridges target (method existence + shapes),
+ *   2. run every bridge-emitted script against that real surface and assert
+ *      the actual effect a WebView would produce.
+ *
+ * window.rsvp is intentionally NOT here: upstream master has no RSVP tab yet
+ * (PR #2009, unmerged) and the rsvp bridge extraction is deferred behind it
+ * (queued as follow-up card t_38ff5fae, merge-dependent). This suite is the
+ * drift tripwire for the assets master ships today.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import {
+  readerSetAdjacentChaptersScript,
+  readerSetBatteryLevelGuardedScript,
+  readerSetBatteryLevelScript,
+  readerSetGeneralSettingsScript,
+  readerSetSettingsScript,
+} from '../reader';
+import { readerSearchScript } from '../search';
+import {
+  ttsCompleteScript,
+  ttsSetActiveIndexScript,
+  ttsSetPlaybackStateScript,
+} from '../tts';
+
+const ASSET_DIR = join(process.cwd(), 'assets', 'reader', 'js');
+
+type PostMessage = { type: string; data?: unknown };
+
+interface FakeElement {
+  nodeName: string;
+  innerText: string;
+  innerHTML: string;
+  scrollHeight: number;
+  scrollWidth: number;
+  childNodes: { length: number; item: (i: number) => unknown };
+  children: unknown[];
+  classList: { add: () => void; remove: () => void; contains: () => boolean };
+  style: { cssText: string; setProperty: () => void; remove: () => void };
+  hasChildNodes: () => boolean;
+  isSameNode: (other: unknown) => boolean;
+  addEventListener: () => void;
+  appendChild: () => void;
+  removeChild: () => void;
+}
+
+const makeElement = (
+  text = '',
+  childElements: FakeElement[] = [],
+  nodeName = 'P',
+): FakeElement => ({
+  nodeName,
+  innerText: text,
+  innerHTML: text,
+  scrollHeight: 0,
+  scrollWidth: 0,
+  childNodes: {
+    length: childElements.length,
+    item: (i: number) => childElements[i] ?? null,
+  },
+  children: childElements,
+  classList: {
+    add: () => undefined,
+    remove: () => undefined,
+    contains: () => false,
+  },
+  style: { cssText: '', setProperty: () => undefined, remove: () => undefined },
+  hasChildNodes: () => childElements.length > 0,
+  isSameNode: other => other === null,
+  addEventListener: () => undefined,
+  appendChild: () => undefined,
+  removeChild: () => undefined,
+});
+
+const initialReaderConfig = {
+  readerSettings: { theme: '#ffffff', tts: {} },
+  chapterGeneralSettings: { pageReader: false },
+  novel: {},
+  chapter: {},
+  batteryLevel: 50,
+  autoSaveInterval: 2222,
+  DEBUG: false,
+  strings: {},
+};
+
+interface LoadedAssets {
+  windowObj: Record<string, unknown>;
+  /**
+   * Evaluate an arbitrary script in the same stub environment core.js saw.
+   * Injected bridge scripts must resolve the reader global to the REAL
+   * window.reader core.js created, so readerOverride defaults to that.
+   */
+  evaluate: (script: string, readerOverride?: unknown) => void;
+}
+
+const loadAssets = (): LoadedAssets => {
+  const posted: PostMessage[] = [];
+  const chapterElement = makeElement('<p>Hello, world!</p>', [], 'DIV');
+  const elements = [makeElement('First paragraph of text.', [], 'SPAN')];
+  chapterElement.innerHTML = '';
+  chapterElement.childNodes = {
+    length: elements.length,
+    item: (i: number) => elements[i] ?? null,
+  };
+  chapterElement.children = elements;
+
+  const windowObj: Record<string, unknown> = {
+    getSelection: () => ({ removeAllRanges: () => undefined }),
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    innerHeight: 800,
+    innerWidth: 400,
+    scrollTo: () => undefined,
+  };
+  const readerStub = {
+    chapterElement,
+    post: (obj: PostMessage) => posted.push(obj),
+    readerSettings: { val: initialReaderConfig.readerSettings },
+    generalSettings: { val: initialReaderConfig.chapterGeneralSettings },
+    nextChapter: undefined,
+    refresh: () => undefined,
+  };
+  const vanStub = {
+    state: (v: unknown) => ({ val: v }),
+    derive: () => undefined,
+  };
+  const getComputedStyleStub = () => ({
+    color: '#000',
+    backgroundColor: '#fff',
+    getPropertyValue: () => '0px',
+    setProperty: (prop: string, value: string) => {
+      (readerStub as unknown as Record<string, unknown>)[prop] = value;
+    },
+  });
+  const setTimeoutStub = () => 0;
+  const clearTimeoutStub = () => undefined;
+  const setIntervalStub = () => 0;
+  const clearIntervalStub = () => undefined;
+
+  const documentStub = {
+    getElementById: () => null,
+    createElement: (_tag?: string) => makeElement(''),
+    addEventListener: () => undefined,
+    querySelector: (sel: string) =>
+      sel === '#LNReader-chapter' ? chapterElement : makeElement(''),
+    querySelectorAll: () => [],
+    getElementsByClassName: () => [],
+    documentElement: makeElement(''),
+    body: makeElement(''),
+    createElementNS: () => makeElement(''),
+    createDocumentFragment: () => makeElement(''),
+    createTreeWalker: () => ({ nextNode: () => null }),
+    createRange: () => ({
+      selectNodeContents: () => undefined,
+      extractContents: () => makeElement(''),
+      createContextualFragment: () => makeElement(''),
+    }),
+  };
+
+  const params = {
+    window: windowObj,
+    document: documentStub,
+    console,
+    setTimeout: setTimeoutStub,
+    clearTimeout: clearTimeoutStub,
+    setInterval: setIntervalStub,
+    clearInterval: clearIntervalStub,
+    reader: readerStub,
+    initialReaderConfig,
+    initialPageReaderConfig: {},
+    van: vanStub,
+    pageReader: undefined,
+    ReactNativeWebView: { postMessage: () => undefined },
+    location: {},
+    history: {},
+    navigator: {},
+    getComputedStyle: getComputedStyleStub,
+    getSelection: () => ({ removeAllRanges: () => undefined }),
+    Node: {},
+    Element: {},
+    ResizeObserver: class {
+      observe() {
+        return undefined;
+      }
+      disconnect() {
+        return undefined;
+      }
+      unobserve() {
+        return undefined;
+      }
+    },
+  };
+
+  const evaluate = (script: string, readerOverride?: unknown) => {
+    // After core.js ran, windowObj.reader IS the global `reader` the emitted
+    // bridge scripts reference (browsers resolve bare window properties) —
+    // resolve it that way; during the core.js load itself the fallback stub
+    // is used, exactly as in the #1576 contract suite.
+    const reader = readerOverride ?? windowObj.reader ?? readerStub;
+    const fn = new Function(...Object.keys(params), script);
+    const values = Object.values(params);
+    const readerIndex = Object.keys(params).indexOf('reader');
+    if (reader !== readerStub) {
+      values[readerIndex] = reader;
+    }
+    fn(...values);
+  };
+
+  evaluate(readFileSync(join(ASSET_DIR, 'core.js'), 'utf8'));
+  evaluate(readFileSync(join(ASSET_DIR, 'search.js'), 'utf8'));
+  return { windowObj, evaluate };
+};
+
+const ttsSurface = (env: LoadedAssets) =>
+  env.windowObj.tts as Record<string, unknown>;
+const readerSurface = (env: LoadedAssets) =>
+  env.windowObj.reader as Record<string, unknown>;
+
+describe('core.js / search.js surface parity', () => {
+  let env: LoadedAssets;
+  beforeEach(() => {
+    env = loadAssets();
+  });
+
+  it('window.reader exposes the state slots the bridge scripts target', () => {
+    const reader = readerSurface(env);
+    for (const slot of ['readerSettings', 'generalSettings', 'batteryLevel']) {
+      expect(reader[slot]).toBeDefined();
+      expect(typeof (reader[slot] as { val?: unknown }).val).not.toBe(
+        'undefined',
+      );
+    }
+    expect(typeof reader.setAdjacentChapters).toBe('function');
+    expect(typeof reader.hidden).toBeDefined();
+  });
+
+  it('window.tts exposes the methods the tts bridge scripts call', () => {
+    const tts = ttsSurface(env);
+    for (const method of [
+      'start',
+      'complete',
+      'setActiveIndex',
+      'setPlaybackState',
+    ]) {
+      expect(typeof tts[method]).toBe('function');
+    }
+  });
+
+  it('window.tts.readableNodeNames keeps the traversal constants the TTS walk relies on', () => {
+    const tts = ttsSurface(env);
+    const names = tts.readableNodeNames as string[];
+    expect(Array.isArray(names)).toBe(true);
+    for (const required of [
+      '#text',
+      'B',
+      'I',
+      'EM',
+      'SPAN',
+      'STRONG',
+      'A',
+      'MARK',
+    ]) {
+      expect(names).toContain(required);
+    }
+  });
+
+  it('window.readerSearch exposes the methods the search bridge targets', () => {
+    const search = env.windowObj.readerSearch as Record<string, unknown>;
+    expect(search).toBeDefined();
+    for (const method of ['search', 'clear', 'next', 'previous']) {
+      expect(typeof search[method]).toBe('function');
+    }
+  });
+
+  it('tts setPlaybackState script drives the real surface (WebView truth)', () => {
+    env.evaluate(ttsSetPlaybackStateScript('playing'));
+    const tts = ttsSurface(env);
+    expect((tts as { reading: boolean }).reading).toBe(true);
+
+    env.evaluate(ttsSetPlaybackStateScript('paused'));
+    expect((tts as { reading: boolean }).reading).toBe(false);
+  });
+
+  it('tts complete + setActiveIndex scripts run without throwing on the real surface', () => {
+    expect(() => env.evaluate(ttsCompleteScript())).not.toThrow();
+    expect(() => env.evaluate(ttsSetActiveIndexScript(0))).not.toThrow();
+  });
+
+  it('reader settings script replaces the real readerSettings.val', () => {
+    const settings = { theme: '#123456', tts: { rate: 1.2 } };
+    env.evaluate(readerSetSettingsScript(settings as never));
+    const reader = readerSurface(env);
+    expect(JSON.parse(JSON.stringify(reader.readerSettings))).toEqual({
+      val: settings,
+    });
+  });
+
+  it('reader general-settings script replaces the real generalSettings.val', () => {
+    env.evaluate(readerSetGeneralSettingsScript({ pageReader: true } as never));
+    const reader = readerSurface(env);
+    expect(
+      (reader.generalSettings as { val: { pageReader: boolean } }).val
+        .pageReader,
+    ).toBe(true);
+  });
+
+  it('battery scripts set the real batteryLevel.val', () => {
+    env.evaluate(readerSetBatteryLevelScript(42));
+    const reader = readerSurface(env);
+    expect((reader.batteryLevel as { val: number }).val).toBe(42);
+
+    env.evaluate(readerSetBatteryLevelGuardedScript(7));
+    expect((reader.batteryLevel as { val: number }).val).toBe(7);
+  });
+
+  it('adjacent-chapters script hands payload to the real setAdjacentChapters', () => {
+    env.evaluate(
+      readerSetAdjacentChaptersScript(
+        { id: 7, name: 'Next' } as never,
+        undefined,
+        { nextChapter: 'Next' },
+      ),
+    );
+    const reader = readerSurface(env) as {
+      nextChapter?: { id: number };
+      nextChapterName?: void;
+      strings: Record<string, unknown>;
+      adjacentVersion: { val: number };
+    };
+    expect(reader.nextChapter).toEqual({ id: 7, name: 'Next' });
+    expect(reader.strings.nextChapter).toBe('Next');
+    expect(reader.adjacentVersion.val).toBeGreaterThan(0);
+  });
+
+  it('search script emission parses and targets the real surface', () => {
+    // search() itself is an asynchronous DOM-walker (createTreeWalker over
+    // chapter segments) that needs a full DOM implementation, which this
+    // stub deliberately does not provide — that behavior is search.js's own
+    // domain. The bridge contract here is: emission parses and the method
+    // surface exists (pinned above), so a rename or syntax break in either
+    // side fails this suite.
+    const script = readerSearchScript('test');
+    expect(() => new Function('window', script)).not.toThrow();
+    expect(
+      typeof (env.windowObj.readerSearch as Record<string, unknown>).search,
+    ).toBe('function');
+  });
+});

--- a/src/screens/reader/bridge/__tests__/coreSurface.test.ts
+++ b/src/screens/reader/bridge/__tests__/coreSurface.test.ts
@@ -28,7 +28,7 @@ import {
   readerSetGeneralSettingsScript,
   readerSetSettingsScript,
 } from '../reader';
-import { readerSearchScript } from '../search';
+import { readerSearchNavigateScript, readerSearchScript } from '../search';
 import {
   ttsCompleteScript,
   ttsSetActiveIndexScript,
@@ -356,5 +356,19 @@ describe('core.js / search.js surface parity', () => {
     expect(
       typeof (env.windowObj.readerSearch as Record<string, unknown>).search,
     ).toBe('function');
+  });
+
+  it('search navigate emissions parse and target the real next/previous surface', () => {
+    // Mirrors the search-emission contract test: navigate scripts spell the
+    // method literally (the #2009 seam this suite guards against) and the
+    // real surface exposes those exact methods.
+    for (const direction of ['NEXT', 'PREV'] as const) {
+      const script = readerSearchNavigateScript(direction, 'test');
+      expect(() => new Function('window', script)).not.toThrow();
+      const method = direction === 'NEXT' ? 'next' : 'previous';
+      expect(
+        typeof (env.windowObj.readerSearch as Record<string, unknown>)[method],
+      ).toBe('function');
+    }
   });
 });

--- a/src/screens/reader/bridge/__tests__/coreSurface.test.ts
+++ b/src/screens/reader/bridge/__tests__/coreSurface.test.ts
@@ -3,11 +3,11 @@
  * WebView assets.
  *
  * Paranoia, exactly: the bridge modules emit scripts for window.tts /
- * window.reader / window.readerSearch. If the JS asset renames a method or
- * drops a state slot, those scripts silently no-op on device — the #2009
- * class of failure. These tests load the real assets/reader/js/core.js and
- * assets/reader/js/search.js in a minimal DOM stub (the pattern proven by
- * #1576's rsvpBridge.test.ts) and then:
+ * window.reader / window.readerSearch / window.pageReader. If the JS asset
+ * renames a method or drops a state slot, those scripts silently no-op on
+ * device — the #2009 class of failure. These tests load the real
+ * assets/reader/js/core.js and assets/reader/js/search.js in a minimal DOM
+ * stub (the pattern proven by #1576's rsvpBridge.test.ts) and then:
  *   1. pin the surfaces the TS bridges target (method existence + shapes),
  *   2. run every bridge-emitted script against that real surface and assert
  *      the actual effect a WebView would produce.
@@ -34,6 +34,7 @@ import {
   ttsSetActiveIndexScript,
   ttsSetPlaybackStateScript,
 } from '../tts';
+import { pageReaderMovePageScript } from '../pageReader';
 
 const ASSET_DIR = join(process.cwd(), 'assets', 'reader', 'js');
 
@@ -183,6 +184,14 @@ const loadAssets = (): LoadedAssets => {
     van: vanStub,
     pageReader: undefined,
     ReactNativeWebView: { postMessage: () => undefined },
+    // Browsers resolve bare window properties as globals; core.js internals
+    // (window.pageReader.movePage among them) call onUserInteraction()
+    // without a window prefix. The evaluator's new Function scopes that bare
+    // identifier to this parameter binding, fixed at core.js load time, so
+    // supply a stable no-op: the interaction-grouping side effect
+    // (reader.post) is not part of the parity surface under test, and a
+    // deterministic handler keeps these scripts runnable in the stub.
+    onUserInteraction: () => undefined,
     location: {},
     history: {},
     navigator: {},
@@ -370,5 +379,22 @@ describe('core.js / search.js surface parity', () => {
         typeof (env.windowObj.readerSearch as Record<string, unknown>)[method],
       ).toBe('function');
     }
+  });
+
+  it('window.pageReader exposes the methods the pageReader bridge targets', () => {
+    const pageReader = env.windowObj.pageReader as Record<string, unknown>;
+    expect(pageReader).toBeDefined();
+    expect(typeof pageReader.movePage).toBe('function');
+  });
+
+  it('pageReader movePage emission parses and runs against the real surface', () => {
+    // movePage(0) is the exact emission ReaderScreen.tsx makes when the
+    // pageReader setting is enabled (scroll-to-start). In this stub the
+    // chapter sits at the first page with no adjacent chapter, so the real
+    // surface must no-op — never throw. The method name is a fixed literal,
+    // so the #2009 hazard class cannot appear here.
+    const script = pageReaderMovePageScript(0);
+    expect(() => new Function('window', script)).not.toThrow();
+    expect(() => env.evaluate(script)).not.toThrow();
   });
 });

--- a/src/screens/reader/bridge/__tests__/customJs.test.ts
+++ b/src/screens/reader/bridge/__tests__/customJs.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Custom-JS bridge contract tests — generalized RsvpTab pattern.
+ *
+ * The custom-JS inline block is embedded into the serialized chapter HTML,
+ * so the tests assert the two failure modes a WebView exposes there:
+ *   1. The emitted body must parse (a SyntaxError inside the page would
+ *      silently kill the inline script and the whole wrapper).
+ *   2. User text can never terminate the <script> tag early — the `</script`
+ *      breakout sequence must be escaped in the raw text, while still
+ *      spelling `</script>` at runtime (JS string escapes are transparent).
+ */
+
+import { buildCustomJsInlineScript } from '../customJs';
+
+interface DocumentStub {
+  html: string;
+  listeners: Record<string, (() => void) | undefined>;
+  querySelector: (sel: string) => { innerHTML: string } | null;
+  addEventListener: (event: string, fn: () => void) => void;
+}
+
+const makeDocumentStub = (initialHtml: string): DocumentStub => {
+  const doc = {} as DocumentStub;
+  doc.html = initialHtml;
+  doc.listeners = {};
+  const element = {
+    get innerHTML() {
+      return doc.html;
+    },
+    set innerHTML(value: string) {
+      doc.html = value;
+    },
+  };
+  doc.querySelector = sel => (sel === '#LNReader-chapter' ? element : null);
+  doc.addEventListener = (event, fn) => {
+    doc.listeners[event] = fn;
+  };
+  return doc;
+};
+
+/** Evaluates the inline body like the browser would; runs the wrapper. */
+const runInlineScript = (
+  customJs: string,
+  initialHtml: string,
+  windows?: Record<string, unknown>,
+) => {
+  const doc = makeDocumentStub(initialHtml);
+  const body = buildCustomJsInlineScript(customJs);
+  // Parse the whole body: a SyntaxError here means the WebView dropped the
+  // entire inline script before running anything.
+  const evaluate = new Function('window', 'document', body);
+  evaluate(windows ?? {}, doc);
+  return { doc, body };
+};
+
+describe('customJs bridge — inline script contract', () => {
+  it('emits a parseable script body for a snippet, even a snippet with newlines', () => {
+    const doc = makeDocumentStub('');
+    const { body } = runInlineScript('const x = 1;\nconst y = x + 1;', '');
+    // Executing the parsed body with a document stub proves the whole inline
+    // script is evaluable — a SyntaxError here dies inside the WebView too.
+    expect(() => new Function('document', body)(doc)).not.toThrow();
+  });
+
+  it('emits a parseable body when there is no custom JS at all', () => {
+    const { body } = runInlineScript('', '');
+    expect(() => new Function('document', body)).not.toThrow();
+  });
+
+  it('runs the user snippet exactly once, between reading and writing HTML', () => {
+    const calls: string[] = [];
+    const snippet = `window.__customJsProbe = 'ran';`;
+    const body = buildCustomJsInlineScript(snippet);
+    const evaluate = new Function('window', 'document', 'globals', body);
+    // The wrapper captures the element once at fn() run time; instrument the
+    // element so we can see the exact order read → snippet → write.
+    const element = {
+      get innerHTML() {
+        calls.push('read');
+        return '<p>initial</p>';
+      },
+      set innerHTML(value: string) {
+        calls.push(`write:${value}`);
+      },
+    };
+    const docStub = {
+      querySelector: (sel: string) =>
+        sel === '#LNReader-chapter' ? element : null,
+      addEventListener: (_event: string, fn: () => void) => {
+        // fire DOMContentLoaded the moment it is registered
+        callListeners.push(fn);
+      },
+    };
+    const callListeners: (() => void)[] = [];
+    evaluate({ __customJsProbe: undefined }, docStub, {});
+    callListeners[0]?.();
+    expect(calls).toEqual(['read', 'write:<p>initial</p>']);
+  });
+
+  it('escapes `</script` so user code cannot terminate the inline script tag', () => {
+    const { body } = runInlineScript(
+      `probe('</script><script>alert(1)</script>')`,
+      '',
+    );
+    // Raw text must never contain the breakout sequence...
+    expect(body).not.toMatch(/<\/script/gi);
+    // ...but must carry it escaped, and the escape must be transparent at
+    // runtime (the JS engine resumes `</script>` inside the string).
+    expect(body).toMatch(/<\\\/script/gi);
+  });
+
+  it('escaped `</script` evaluates back to its original value at runtime', () => {
+    const doc = makeDocumentStub('<p>initial</p>');
+    const body = buildCustomJsInlineScript(`window.__escaped = '</script>';`);
+    const windowObject: Record<string, unknown> = {};
+    const evaluate = new Function('window', 'document', body);
+    expect(() => evaluate(windowObject, doc)).not.toThrow();
+    // The snippet runs inside fn(), which the browser fires on
+    // DOMContentLoaded — fire it the way the wrapper registers it.
+    doc.listeners['DOMContentLoaded']?.();
+    expect(windowObject.__escaped).toBe('</script>');
+  });
+
+  it('wraps the snippet with read → snippet → write in one DOMContentLoaded fn', () => {
+    const body = buildCustomJsInlineScript('/* custom */');
+    const readIdx = body.indexOf(
+      "let html = document.querySelector('#LNReader-chapter').innerHTML;",
+    );
+    const snippetIdx = body.indexOf('/* custom */');
+    const writeIdx = body.indexOf(
+      "document.querySelector('#LNReader-chapter').innerHTML = html;",
+    );
+    const loadedIdx = body.indexOf(
+      "document.addEventListener('DOMContentLoaded', fn);",
+    );
+    expect(readIdx).toBeGreaterThanOrEqual(0);
+    expect(readIdx).toBeLessThan(snippetIdx);
+    expect(snippetIdx).toBeLessThan(writeIdx);
+    expect(writeIdx).toBeLessThan(loadedIdx);
+  });
+});

--- a/src/screens/reader/bridge/__tests__/pageReader.test.ts
+++ b/src/screens/reader/bridge/__tests__/pageReader.test.ts
@@ -1,0 +1,61 @@
+/**
+ * pageReader bridge injection contract tests — RsvpTab.test.tsx pattern,
+ * generalized to the pageReader bridge module surface.
+ *
+ * Contract: every bridge function returns a script that a WebView can
+ * actually evaluate, and that script invokes the intended window.pageReader
+ * method with the intended (sanitized) argument. Tests parse the whole
+ * string, then run it against an instrumented window.pageReader exactly as
+ * the WebView would.
+ */
+
+import { pageReaderMovePageScript } from '../pageReader';
+
+const PAGE_READER_METHODS = ['movePage'] as const;
+
+interface RunEnv {
+  window: { pageReader: Record<string, (...args: unknown[]) => void> };
+}
+
+/** Parses and runs a script like the WebView would; returns invocations. */
+const runScriptLikeWebView = (script: string, env: RunEnv): string[] => {
+  const calls: string[] = [];
+  const recording: Record<string, (...args: unknown[]) => void> = {};
+  for (const method of PAGE_READER_METHODS) {
+    recording[method] = (...args: unknown[]) =>
+      calls.push(`${method}(${args.join(', ')})`);
+  }
+  const resolved: Record<string, unknown> = {
+    window: { ...env.window, pageReader: recording },
+  };
+  const evaluate = new Function('window', script);
+  evaluate(resolved.window);
+  return calls;
+};
+
+describe('pageReader bridge — WebView injection', () => {
+  it('movePage emits an evaluable script that jumps to the requested page', () => {
+    const calls = runScriptLikeWebView(pageReaderMovePageScript(0), {
+      window: { pageReader: {} },
+    });
+    expect(calls).toEqual(['movePage(0)']);
+  });
+
+  it('sanitizes non-finite page numbers so emission always parses', () => {
+    for (const invalid of [NaN, Infinity, -Infinity]) {
+      const script = pageReaderMovePageScript(invalid);
+      expect(() => new Function('window', script)).not.toThrow();
+      expect(
+        runScriptLikeWebView(script, { window: { pageReader: {} } }),
+      ).toEqual(['movePage(0)']);
+    }
+  });
+
+  it('sanitizes fractional page numbers to integers', () => {
+    expect(
+      runScriptLikeWebView(pageReaderMovePageScript(2.6), {
+        window: { pageReader: {} },
+      }),
+    ).toEqual(['movePage(3)']);
+  });
+});

--- a/src/screens/reader/bridge/__tests__/reader.test.ts
+++ b/src/screens/reader/bridge/__tests__/reader.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Reader-state bridge injection contract tests — RsvpTab.test.tsx pattern,
+ * generalized to the bridge module surface.
+ *
+ * Contract: every bridge function returns a script that a WebView can
+ * actually evaluate, and that script sets exactly the intended state on the
+ * instrumented window.reader / window.readerSearch, or calls the intended
+ * window.reader method. Scripts reference bare globals (reader.*) exactly as
+ * WebViewReader emitted them before this module existed, so the harness
+ * passes those globals in as parameters the way the browser global scope
+ * would resolve them.
+ */
+
+import {
+  readerSetAdjacentChaptersScript,
+  readerSetBatteryLevelGuardedScript,
+  readerSetBatteryLevelScript,
+  readerSetGeneralSettingsScript,
+  readerSetSettingsScript,
+} from '../reader';
+import { readerSearchScript } from '../search';
+
+/** Records `val` writes with the exact JSON the WebView state would hold. */
+const makeStateSlot = (calls: string[], label: string) => {
+  let current: unknown;
+  return {
+    get val() {
+      return current;
+    },
+    set val(value: unknown) {
+      current = value;
+      calls.push(`${label}=${JSON.stringify(value)}`);
+    },
+  };
+};
+
+interface RunEnv {
+  reader?: {
+    readerSettings?: { val: unknown };
+    generalSettings?: { val: unknown };
+    batteryLevel?: { val: unknown };
+  };
+  readerSearch?: Record<string, (...args: unknown[]) => void>;
+  adjacentChapters?: (payload: unknown) => void;
+}
+
+interface RunResult {
+  calls: string[];
+  windowStub: Record<string, unknown>;
+}
+
+/** Parses and runs a script like a WebView would; returns captured writes. */
+const runScriptLikeWebView = (script: string, env: RunEnv): RunResult => {
+  const calls: string[] = [];
+  const reader = {
+    readerSettings: makeStateSlot(calls, 'readerSettings'),
+    generalSettings: makeStateSlot(calls, 'generalSettings'),
+    batteryLevel: makeStateSlot(calls, 'batteryLevel'),
+    ...(env.reader ?? {}),
+  };
+  const windowStub: Record<string, unknown> = {
+    reader,
+    readerSearch: env.readerSearch ?? {},
+  };
+  if (env.adjacentChapters) {
+    (windowStub.reader as Record<string, unknown>).setAdjacentChapters =
+      env.adjacentChapters;
+  }
+  const evaluate = new Function('window', 'reader', script);
+  evaluate(windowStub, reader);
+  return { calls, windowStub };
+};
+
+const MINIMAL_READER_SETTINGS = {
+  theme: '#000000',
+  padding: 12,
+  textSize: 18,
+  textColor: '#ffffff',
+  textAlign: 'left',
+  lineHeight: 1.5,
+  fontFamily: 'default',
+  tts: { rate: 1 },
+};
+
+describe('reader bridge — WebView injection', () => {
+  it('setSettings emits a script that replaces reader.readerSettings.val', () => {
+    const { calls } = runScriptLikeWebView(
+      readerSetSettingsScript(MINIMAL_READER_SETTINGS as never),
+      {},
+    );
+    expect(calls).toEqual([
+      'readerSettings={"theme":"#000000","padding":12,"textSize":18,"textColor":"#ffffff","textAlign":"left","lineHeight":1.5,"fontFamily":"default","tts":{"rate":1}}',
+    ]);
+  });
+
+  it('setSettings serializes settings with quotes without breaking the script', () => {
+    const settings = { fontFamily: 'Fraunces" <- injected' };
+    const { calls } = runScriptLikeWebView(
+      readerSetSettingsScript(settings as never),
+      {},
+    );
+    expect(calls).toEqual([
+      'readerSettings={"fontFamily":"Fraunces\\" <- injected"}',
+    ]);
+    // The emission itself must parse: JSON.stringify leaves no raw quote in
+    // the string literal context.
+    expect(
+      () =>
+        new Function(
+          'window',
+          'reader',
+          readerSetSettingsScript(settings as never),
+        ),
+    ).not.toThrow();
+  });
+
+  it('setGeneralSettings emits a script that replaces reader.generalSettings.val', () => {
+    const { calls } = runScriptLikeWebView(
+      readerSetGeneralSettingsScript({ pageReader: true } as never),
+      {},
+    );
+    expect(calls).toEqual(['generalSettings={"pageReader":true}']);
+  });
+
+  it('setBatteryLevel emits a script that sets reader.batteryLevel.val', () => {
+    const { calls } = runScriptLikeWebView(readerSetBatteryLevelScript(87), {});
+    expect(calls).toEqual(['batteryLevel=87']);
+  });
+
+  it('guarded battery script no-ops before window.reader boots', () => {
+    const script = readerSetBatteryLevelGuardedScript(87);
+    // The guard renders `window.reader?.batteryLevel` then writes to it; with
+    // a window stub lacking reader the script must neither throw nor write.
+    const evaluate = new Function('window', script);
+    expect(() => evaluate({})).not.toThrow();
+  });
+
+  it('guarded battery script works once window.reader.batteryLevel exists', () => {
+    const script = readerSetBatteryLevelGuardedScript(72);
+    const batteryLevel = { val: 0 };
+    const evaluate = new Function('window', script);
+    evaluate({ reader: { batteryLevel } });
+    expect(batteryLevel.val).toBe(72);
+  });
+
+  it('setAdjacentChapters emits a script that hands next/prev + strings to window.reader', () => {
+    let received: unknown;
+    const script = readerSetAdjacentChaptersScript(
+      { id: 7, name: 'Next Chapter' } as never,
+      { id: 6, name: 'Prev Chapter' } as never,
+      { nextChapter: 'Next Chapter' },
+    );
+    // parse like a WebView would and execute against an instrumented stub
+    const evaluate = new Function('window', 'reader', script);
+    evaluate(
+      {
+        reader: {
+          setAdjacentChapters: (payload: unknown) => {
+            received = payload;
+          },
+        },
+      },
+      {},
+    );
+    const payload = received as {
+      nextChapter?: { id: number; name: string };
+      prevChapter?: { id: number; name: string };
+      strings?: { nextChapter: string };
+    };
+    expect(payload.nextChapter).toEqual({ id: 7, name: 'Next Chapter' });
+    expect(payload.prevChapter).toEqual({ id: 6, name: 'Prev Chapter' });
+    expect(payload.strings).toEqual({ nextChapter: 'Next Chapter' });
+  });
+
+  it('setAdjacentChapters tolerates missing chapters', () => {
+    let received: unknown;
+    const evaluate = new Function(
+      'window',
+      'reader',
+      readerSetAdjacentChaptersScript(undefined, undefined, {
+        nextChapter: '',
+      }),
+    );
+    evaluate(
+      {
+        reader: {
+          setAdjacentChapters: (payload: unknown) => {
+            received = payload;
+          },
+        },
+      },
+      {},
+    );
+    const payload = received as {
+      nextChapter?: unknown;
+      prevChapter?: unknown;
+    };
+    expect(payload.nextChapter).toBeUndefined();
+    expect(payload.prevChapter).toBeUndefined();
+  });
+});
+
+describe('search bridge — WebView injection', () => {
+  it('search emits a script that searches the page with the given query', () => {
+    const captured: string[] = [];
+    const evaluate = new Function('window', readerSearchScript('The Great'));
+    evaluate({
+      readerSearch: { search: (query: string) => captured.push(query) },
+    });
+    expect(captured).toEqual(['The Great']);
+  });
+
+  it('search JSON-escapes tricky queries', () => {
+    const captured: string[] = [];
+    const evaluate = new Function(
+      'window',
+      readerSearchScript('say "hi" \\ backslash'),
+    );
+    evaluate({
+      readerSearch: { search: (query: string) => captured.push(query) },
+    });
+    expect(captured).toEqual(['say "hi" \\ backslash']);
+    expect(
+      () => new Function('window', readerSearchScript('say "hi" \\ backslash')),
+    ).not.toThrow();
+  });
+});

--- a/src/screens/reader/bridge/__tests__/reader.test.ts
+++ b/src/screens/reader/bridge/__tests__/reader.test.ts
@@ -18,7 +18,7 @@ import {
   readerSetGeneralSettingsScript,
   readerSetSettingsScript,
 } from '../reader';
-import { readerSearchScript } from '../search';
+import { readerSearchNavigateScript, readerSearchScript } from '../search';
 
 /** Records `val` writes with the exact JSON the WebView state would hold. */
 const makeStateSlot = (calls: string[], label: string) => {
@@ -222,6 +222,61 @@ describe('search bridge — WebView injection', () => {
     expect(captured).toEqual(['say "hi" \\ backslash']);
     expect(
       () => new Function('window', readerSearchScript('say "hi" \\ backslash')),
+    ).not.toThrow();
+  });
+
+  it('navigate next emits a script that calls readerSearch.next with the query', () => {
+    const captured: string[] = [];
+    const evaluate = new Function(
+      'window',
+      readerSearchNavigateScript('NEXT', 'The Great'),
+    );
+    evaluate({
+      readerSearch: { next: (query: string) => captured.push(query) },
+    });
+    expect(captured).toEqual(['The Great']);
+  });
+
+  it('navigate previous emits a script that calls readerSearch.previous with the query', () => {
+    const captured: string[] = [];
+    const evaluate = new Function(
+      'window',
+      readerSearchNavigateScript('PREV', 'The Great'),
+    );
+    evaluate({
+      readerSearch: { previous: (query: string) => captured.push(query) },
+    });
+    expect(captured).toEqual(['The Great']);
+  });
+
+  it('navigate scripts spell the method name literally, never by interpolation', () => {
+    // The seam this function closes (PR #2009 hazard class): the injected
+    // script must never carry a computed method name, only the literals
+    // `next` / `previous` resolvable to the real surface.
+    expect(readerSearchNavigateScript('NEXT', 'x')).toBe(
+      'window.readerSearch?.next("x"); true;',
+    );
+    expect(readerSearchNavigateScript('PREV', 'x')).toBe(
+      'window.readerSearch?.previous("x"); true;',
+    );
+  });
+
+  it('navigate JSON-escapes tricky queries', () => {
+    const captured: string[] = [];
+    const evaluate = new Function(
+      'window',
+      readerSearchNavigateScript('NEXT', 'say "hi" again'),
+    );
+    evaluate({
+      readerSearch: { next: (query: string) => captured.push(query) },
+    });
+    expect(captured).toEqual(['say "hi" again']);
+    expect(
+      () =>
+        new Function(
+          'window',
+          readerSearchNavigateScript('NEXT', 'say "hi" again'),
+        ),
     ).not.toThrow();
   });
 });

--- a/src/screens/reader/bridge/__tests__/tts.test.ts
+++ b/src/screens/reader/bridge/__tests__/tts.test.ts
@@ -1,0 +1,120 @@
+/**
+ * TTS bridge injection contract tests — RsvpTab.test.tsx pattern,
+ * generalized to the bridge module surface.
+ *
+ * Contract: every bridge function returns a script that a WebView can
+ * actually evaluate, and that script invokes the intended window.tts
+ * method with the intended arguments. Tests parse the whole string, then
+ * run it against an instrumented window.tts exactly as the WebView would.
+ */
+
+import {
+  ttsAutoStartScript,
+  ttsCompleteScript,
+  ttsSetActiveIndexScript,
+  ttsSetPlaybackStateScript,
+} from '../tts';
+
+const TTS_METHODS = [
+  'start',
+  'setPlaybackState',
+  'setActiveIndex',
+  'complete',
+] as const;
+
+interface RunEnv {
+  window: { tts: Record<string, (...args: unknown[]) => void> };
+  reader?: Record<string, unknown>;
+}
+
+/** Parses and runs a script like the WebView would; returns invocations. */
+const runScriptLikeWebView = (script: string, env: RunEnv): string[] => {
+  const calls: string[] = [];
+  const recording: Record<string, (...args: unknown[]) => void> = {};
+  for (const method of TTS_METHODS) {
+    recording[method] = (...args: unknown[]) =>
+      calls.push(`${method}(${args.join(', ')})`);
+  }
+  const resolved: Record<string, unknown> = {
+    window: { ...env.window, tts: recording },
+    reader: env.reader ?? {},
+  };
+  // Bare `tts` and `reader` resolve off the browser global (window.tts, and
+  // the spliced initialReaderConfig host script) — mirror that by passing
+  // them as parameters, the way the WebView's global scope would see them.
+  const evaluate = new Function(
+    'window',
+    'tts',
+    'reader',
+    'setTimeout',
+    script,
+  );
+  evaluate(resolved.window, recording, resolved.reader, (fn: () => void) =>
+    fn(),
+  );
+  return calls;
+};
+
+describe('tts bridge — WebView injection', () => {
+  it('setPlaybackState emits an evaluable script that updates window.tts', () => {
+    const calls = runScriptLikeWebView(ttsSetPlaybackStateScript('playing'), {
+      window: { tts: {} },
+    });
+    expect(calls).toEqual(['setPlaybackState(playing)']);
+  });
+
+  it('every playback state serializes to a parseeable script', () => {
+    for (const state of [
+      'idle',
+      'loading',
+      'playing',
+      'paused',
+      'completed',
+      'error',
+    ]) {
+      const script = ttsSetPlaybackStateScript(state as any);
+      expect(() => new Function('window', script)).not.toThrow();
+      expect(runScriptLikeWebView(script, { window: { tts: {} } })).toEqual([
+        `setPlaybackState(${state})`,
+      ]);
+    }
+  });
+
+  it('complete emits an evaluable script that completes window.tts', () => {
+    expect(
+      runScriptLikeWebView(ttsCompleteScript(), { window: { tts: {} } }),
+    ).toEqual(['complete()']);
+  });
+
+  it('setActiveIndex emits an evaluable script with a sanitized index', () => {
+    expect(
+      runScriptLikeWebView(ttsSetActiveIndexScript(3), { window: { tts: {} } }),
+    ).toEqual(['setActiveIndex(3)']);
+  });
+
+  it('setActiveIndex sanitizes non-finite indices so emission always parses', () => {
+    for (const invalid of [NaN, Infinity, -Infinity]) {
+      const script = ttsSetActiveIndexScript(invalid);
+      expect(() => new Function('window', script)).not.toThrow();
+      expect(runScriptLikeWebView(script, { window: { tts: {} } })).toEqual([
+        'setActiveIndex(0)',
+      ]);
+    }
+  });
+
+  it('autoStart no-ops when TTS is disabled in reader settings', () => {
+    const calls = runScriptLikeWebView(ttsAutoStartScript(), {
+      window: { tts: {} },
+      reader: { generalSettings: { val: { TTSEnable: false } } },
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it('autoStart starts TTS when enabled, mirroring the onLoadEnd path', () => {
+    const calls = runScriptLikeWebView(ttsAutoStartScript(), {
+      window: { tts: {} },
+      reader: { generalSettings: { val: { TTSEnable: true } } },
+    });
+    expect(calls).toEqual(['start()']);
+  });
+});

--- a/src/screens/reader/bridge/customJs.ts
+++ b/src/screens/reader/bridge/customJs.ts
@@ -1,0 +1,36 @@
+/**
+ * Custom-JS bridge — builds the inline <script> body embedded into the
+ * serialized chapter HTML that runs the user's custom JavaScript snippets.
+ *
+ * The wrapper (read chapter HTML → run custom snippets → write chapter HTML
+ * back) is the injection surface user code always goes through. Two
+ * properties are contract-tested:
+ *   - the emitted body is parseable JavaScript (a bad wrapper would break a
+ *     user's whole reader, silently);
+ *   - user-authored text can never terminate the <script> tag early (an
+ *     unescaped `</script` sequence would break the HTML page structure and
+ *     open an injection hole) — `</script` is escaped to `<\/script`, which
+ *     the HTML parser treats as text and the JS engine treats as `</script`
+ *     inside string literals.
+ *
+ * CSS custom code is out of scope here; it is composed by
+ * @utils/customCode and embedded as a style element by the component.
+ */
+
+/** Escape `</script` so an inline script cannot be terminated by its own body. */
+const escapeScriptCloseTag = (code: string): string =>
+  code.replace(/<\/(?=script)/gi, '<\\/');
+
+/**
+ * Build the inline custom-JS body for the chapter HTML. When no custom
+ * JavaScript is configured the wrapper still emits — it is a no-op then —
+ * so the contract (parses, runs, restores HTML) holds for every chapter.
+ */
+export const buildCustomJsInlineScript = (
+  customJs: string,
+): string => `function fn(){
+  let html = document.querySelector('#LNReader-chapter').innerHTML;
+  ${escapeScriptCloseTag(customJs)}
+  document.querySelector('#LNReader-chapter').innerHTML = html;
+}
+document.addEventListener('DOMContentLoaded', fn);`;

--- a/src/screens/reader/bridge/pageReader.ts
+++ b/src/screens/reader/bridge/pageReader.ts
@@ -1,0 +1,18 @@
+/**
+ * PageReader bridge — typed script builders for the reader WebView's
+ * window.pageReader surface.
+ *
+ * Every function returns an injectJavaScript-ready script. Method names are
+ * fixed literals (no string-built interpolation — the #2009 hazard class),
+ * and numeric arguments are sanitized so the emitted text always parses.
+ * The scripts mirror the exact Windows/chrome surface core.js exposes:
+ * movePage (pinned by the core-surface parity test).
+ */
+
+/** Coerce a page number to a finite, rounded integer (0 when absent). */
+const sanitizeNumber = (value: number): number =>
+  Number.isFinite(value) ? Math.round(value) : 0;
+
+/** Jump the page-reader viewport to the given page (0 = first page). */
+export const pageReaderMovePageScript = (page: number): string =>
+  `window.pageReader?.movePage(${sanitizeNumber(page)}); true;`;

--- a/src/screens/reader/bridge/reader.ts
+++ b/src/screens/reader/bridge/reader.ts
@@ -1,0 +1,65 @@
+/**
+ * Reader-state bridge — typed, per-command script builders for the reader
+ * WebView's window.reader surface (settings, battery, adjacent chapters).
+ *
+ * Every function returns an injectJavaScript-ready script; method names are
+ * fixed literals and settings payloads are JSON-serialized, so the #2009
+ * hazard class (string-built method interpolation) cannot occur here.
+ * The script bodies mirror exactly what WebViewReader emitted before this
+ * module existed — including the two battery forms: the unguarded one used
+ * on the device battery listener and the guarded one used at load time,
+ * where the page may not have booted window.reader yet.
+ */
+
+import type { ChapterInfo } from '@database/types';
+import type {
+  ChapterGeneralSettings,
+  ChapterReaderSettings,
+} from '@hooks/persisted/useSettings';
+
+/** Replace the live reader-settings state inside the WebView. */
+export const readerSetSettingsScript = (
+  settings: ChapterReaderSettings,
+): string => `reader.readerSettings.val = ${JSON.stringify(settings)}`;
+
+/** Replace the live general-settings state inside the WebView. */
+export const readerSetGeneralSettingsScript = (
+  settings: ChapterGeneralSettings,
+): string => `reader.generalSettings.val = ${JSON.stringify(settings)}`;
+
+/** Push a raw battery level (native-controlled number, 0-100). */
+export const readerSetBatteryLevelScript = (level: number): string =>
+  `reader.batteryLevel.val = ${level}`;
+
+/**
+ * Push a battery level guarded on the page being booted. Used at load time:
+ * the page sets up window.reader while bootstrapping, and an early update
+ * must be dropped rather than throw.
+ */
+export const readerSetBatteryLevelGuardedScript = (level: number): string =>
+  `if (window.reader?.batteryLevel) {
+    window.reader.batteryLevel.val = ${level};
+  }`;
+
+/** ADJACENT_CHAPTERS strings the WebView needs for the next/prev buttons. */
+export type AdjacentChapterStrings = {
+  nextChapter: string;
+};
+
+/**
+ * Push the resolved neighbouring chapters into the loaded page. The chapter
+ * is rendered before its neighbours are known, so this always runs as an
+ * injection (never baked into the HTML — rebaking would reload the WebView
+ * and lose the reading position).
+ */
+export const readerSetAdjacentChaptersScript = (
+  nextChapter: ChapterInfo | undefined,
+  prevChapter: ChapterInfo | undefined,
+  strings: AdjacentChapterStrings,
+): string => `window.reader?.setAdjacentChapters?.(${JSON.stringify({
+  nextChapter,
+  prevChapter,
+  strings,
+})});
+  true;
+`;

--- a/src/screens/reader/bridge/search.ts
+++ b/src/screens/reader/bridge/search.ts
@@ -2,13 +2,23 @@
  * Search bridge — typed script builders for the reader WebView's
  * window.readerSearch surface.
  *
- * Note: only the search-text emission from WebViewReader (onLoadEnd replay)
- * is routed through this module in this change. The chapter-search
- * navigation emitted from useChapter.ts still uses string-built method
- * interpolation (`window.readerSearch?.${method}(...)` — PR #2009 hazard
- * class) and is tracked as a follow-up.
+ * Every emission names its target method literally: script strings never
+ * carry a computed method name (the PR #2009 hazard class). Used by
+ * WebViewReader (onLoadEnd replay) and useChapter (search-text emission and
+ * NEXT/PREV navigation).
  */
 
 /** Run a search against the page for the given query. */
 export const readerSearchScript = (query: string): string =>
   `window.readerSearch?.search(${JSON.stringify(query)}); true;`;
+
+export type SearchDirection = 'NEXT' | 'PREV';
+
+/** Jump to the next or previous occurrence of the given query. */
+export const readerSearchNavigateScript = (
+  direction: SearchDirection,
+  text: string,
+): string =>
+  direction === 'NEXT'
+    ? `window.readerSearch?.next(${JSON.stringify(text)}); true;`
+    : `window.readerSearch?.previous(${JSON.stringify(text)}); true;`;

--- a/src/screens/reader/bridge/search.ts
+++ b/src/screens/reader/bridge/search.ts
@@ -1,0 +1,14 @@
+/**
+ * Search bridge — typed script builders for the reader WebView's
+ * window.readerSearch surface.
+ *
+ * Note: only the search-text emission from WebViewReader (onLoadEnd replay)
+ * is routed through this module in this change. The chapter-search
+ * navigation emitted from useChapter.ts still uses string-built method
+ * interpolation (`window.readerSearch?.${method}(...)` — PR #2009 hazard
+ * class) and is tracked as a follow-up.
+ */
+
+/** Run a search against the page for the given query. */
+export const readerSearchScript = (query: string): string =>
+  `window.readerSearch?.search(${JSON.stringify(query)}); true;`;

--- a/src/screens/reader/bridge/tts.ts
+++ b/src/screens/reader/bridge/tts.ts
@@ -1,0 +1,42 @@
+/**
+ * TTS bridge — typed, per-command script builders for the reader WebView's
+ * window.tts surface.
+ *
+ * Every function returns an injectJavaScript-ready script. Method names are
+ * fixed literals (no string-built interpolation — the #2009 hazard class),
+ * and numeric arguments are sanitized so the emitted text always parses.
+ * The scripts mirror the exact Windows/chrome surface core.js exposes:
+ * setPlaybackState, setActiveIndex, complete, start (pinned by the
+ * core-surface parity test).
+ */
+
+import type { TtsPlaybackState } from '@modules/nitro-tts';
+
+/** Coerce a control value to a finite, rounded integer (0 when absent). */
+const sanitizeNumber = (value: number): number =>
+  Number.isFinite(value) ? Math.round(value) : 0;
+
+/** Notify the WebView TTS controls of a playback state change. */
+export const ttsSetPlaybackStateScript = (state: TtsPlaybackState): string =>
+  `window.tts?.setPlaybackState?.(${JSON.stringify(state)}); true;`;
+
+/** Signal the WebView that TTS finished the chapter (auto-advance path). */
+export const ttsCompleteScript = (): string =>
+  'window.tts?.complete?.(); true;';
+
+/** Highlight the currently-spoken element in the WebView. */
+export const ttsSetActiveIndexScript = (index: number): string =>
+  `window.tts?.setActiveIndex?.(${sanitizeNumber(index)}); true;`;
+
+/**
+ * Auto-start TTS after the page has loaded, when the reader settings have TTS
+ * enabled. Kept as a guarded IIFE: it must no-op on any device where the
+ * WebView worklet or settings are momentarily unavailable, never throw.
+ */
+export const ttsAutoStartScript = (): string => `(function() {
+  if (window.tts && reader.generalSettings.val.TTSEnable) {
+    setTimeout(() => {
+      tts.start();
+    }, 500);
+  }
+})();`;

--- a/src/screens/reader/components/WebViewReader.tsx
+++ b/src/screens/reader/components/WebViewReader.tsx
@@ -37,6 +37,21 @@ import {
   isChapterRefreshUrl,
   isPluginIssueReportUrl,
 } from '../utils/sanitizeChapterText';
+import {
+  readerSetAdjacentChaptersScript,
+  readerSetBatteryLevelGuardedScript,
+  readerSetBatteryLevelScript,
+  readerSetGeneralSettingsScript,
+  readerSetSettingsScript,
+} from '../bridge/reader';
+import { readerSearchScript } from '../bridge/search';
+import {
+  ttsAutoStartScript,
+  ttsCompleteScript,
+  ttsSetActiveIndexScript,
+  ttsSetPlaybackStateScript,
+} from '../bridge/tts';
+import { buildCustomJsInlineScript } from '../bridge/customJs';
 
 export type WebViewPostEvent = {
   type: string;
@@ -93,22 +108,14 @@ const toNativeTtsSettings = (
  * The adjacent chapters are resolved after the chapter itself is on screen, so
  * they are pushed into the loaded page instead of being baked into the HTML –
  * rebuilding the HTML would reload the WebView and lose the reading position.
+ * The script is built by the reader bridge (readerSetAdjacentChaptersScript),
+ * whose emission is parse-tested; only the i18n strings stay here.
  */
-const buildAdjacentChapterScript = (
-  nextChapter?: ChapterInfo,
-  prevChapter?: ChapterInfo,
-) => `
-  window.reader?.setAdjacentChapters?.(${JSON.stringify({
-    nextChapter,
-    prevChapter,
-    strings: {
-      nextChapter: getString('readerScreen.nextChapter', {
-        name: nextChapter?.name,
-      }),
-    },
-  })});
-  true;
-`;
+const buildAdjacentChapterStrings = (nextChapter?: ChapterInfo) => ({
+  nextChapter: getString('readerScreen.nextChapter', {
+    name: nextChapter?.name,
+  }),
+});
 
 const { RNDeviceInfo } = NativeModules;
 const deviceInfoEmitter = new NativeEventEmitter(RNDeviceInfo);
@@ -169,7 +176,11 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
   const nextChapterScreenVisible = useRef<boolean>(false);
   const autoStartTTSRef = useRef<boolean>(false);
   const activeChapterIdRef = useRef(chapter.id);
-  const adjacentChapterScriptRef = useRef(buildAdjacentChapterScript());
+  const adjacentChapterScriptRef = useRef(
+    readerSetAdjacentChaptersScript(undefined, undefined, {
+      nextChapter: getString('readerScreen.nextChapter', {}),
+    }),
+  );
   const {
     command: runTtsCommand,
     loadAndPlay,
@@ -207,21 +218,17 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
 
   useEffect(() => {
     isTTSReadingRef.current = ttsState === 'playing';
-    webViewRef.current?.injectJavaScript(`
-      window.tts?.setPlaybackState?.(${JSON.stringify(ttsState)});
-      true;
-    `);
+    webViewRef.current?.injectJavaScript(ttsSetPlaybackStateScript(ttsState));
     if (ttsState === 'completed') {
-      webViewRef.current?.injectJavaScript('window.tts?.complete?.(); true;');
+      webViewRef.current?.injectJavaScript(ttsCompleteScript());
     }
   }, [isTTSReadingRef, ttsState, webViewRef]);
 
   useEffect(() => {
     if (ttsProgress.total > 0) {
-      webViewRef.current?.injectJavaScript(`
-        window.tts?.setActiveIndex?.(${ttsProgress.index});
-        true;
-      `);
+      webViewRef.current?.injectJavaScript(
+        ttsSetActiveIndexScript(ttsProgress.index),
+      );
     }
   }, [ttsProgress, webViewRef]);
 
@@ -233,7 +240,11 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
   }, [chapter.id, runTtsCommand]);
 
   useEffect(() => {
-    const script = buildAdjacentChapterScript(nextChapter, prevChapter);
+    const script = readerSetAdjacentChaptersScript(
+      nextChapter,
+      prevChapter,
+      buildAdjacentChapterStrings(nextChapter),
+    );
     // Kept for onLoadEnd: an update that lands before the document is ready is
     // dropped by the WebView, so it is replayed once the page has loaded.
     adjacentChapterScriptRef.current = script;
@@ -259,9 +270,7 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
           }
           // Update WebView settings
           webViewRef.current?.injectJavaScript(
-            `
-            reader.readerSettings.val = ${JSON.stringify(newReaderSettings)}
-            `,
+            readerSetSettingsScript(newReaderSettings),
           );
           break;
         }
@@ -270,9 +279,7 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
             getMMKVObject<ChapterGeneralSettings>(CHAPTER_GENERAL_SETTINGS) ||
             initialChapterGeneralSettings;
           webViewRef.current?.injectJavaScript(
-            `reader.generalSettings.val = ${JSON.stringify(
-              newGeneralSettings,
-            )}`,
+            readerSetGeneralSettingsScript(newGeneralSettings),
           );
           break;
         }
@@ -284,7 +291,7 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
       (level: number) => {
         lastKnownBatteryLevel = level;
         webViewRef.current?.injectJavaScript(
-          `reader.batteryLevel.val = ${level}`,
+          readerSetBatteryLevelScript(level),
         );
       },
     );
@@ -292,9 +299,7 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
     getBatteryLevel().then(level => {
       lastKnownBatteryLevel = level;
       webViewRef.current?.injectJavaScript(
-        `if (window.reader?.batteryLevel) {
-          window.reader.batteryLevel.val = ${level};
-        }`,
+        readerSetBatteryLevelGuardedScript(level),
       );
     });
 
@@ -418,14 +423,9 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
               <script src="${assetsUriPrefix}/js/index.js"></script>
               <script src="${assetsUriPrefix}/js/textRemover.js"></script>
               <script src="${pluginCustomJS}"></script>
-              <script id="ln-custom-js">
-              function fn(){
-                let html = document.querySelector('#LNReader-chapter').innerHTML;
-                ${customJS}
-                document.querySelector('#LNReader-chapter').innerHTML = html;
-              }
-              document.addEventListener('DOMContentLoaded', fn);
-              </script>
+              <script id="ln-custom-js">${buildCustomJsInlineScript(
+                customJS,
+              )}</script>
           </html>
           `,
     };
@@ -434,8 +434,8 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
     chapter,
     chapterGeneralSettings,
     processedHtml,
-      customJS,
-      customCSS,
+    customJS,
+    customCSS,
     initialReaderSettings,
     novel,
     plugin,
@@ -446,33 +446,31 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
   ]);
 
   return (
-      <>
-    <WebView
-      ref={webViewRef}
-      onTouchStart={onTouchStart}
-      style={{ backgroundColor: readerSettings.theme }}
-      allowFileAccess={true}
-      originWhitelist={['*']}
-      scalesPageToFit={true}
-      showsVerticalScrollIndicator={false}
-      javaScriptEnabled={true}
-      webviewDebuggingEnabled={__DEV__}
-      onShouldStartLoadWithRequest={({ url }) => {
-        if (isPluginIssueReportUrl(url)) {
-          void Linking.openURL(url);
-          return false;
-        }
-        if (isChapterRefreshUrl(url)) {
-          refetch();
-          return false;
-        }
-        return true;
-      }}
-      onLoadEnd={() => {
-        webViewRef.current?.injectJavaScript(
-          `if (window.reader && window.reader.batteryLevel) {
-            window.reader.batteryLevel.val = ${lastKnownBatteryLevel};
-          }`,
+    <>
+      <WebView
+        ref={webViewRef}
+        onTouchStart={onTouchStart}
+        style={{ backgroundColor: readerSettings.theme }}
+        allowFileAccess={true}
+        originWhitelist={['*']}
+        scalesPageToFit={true}
+        showsVerticalScrollIndicator={false}
+        javaScriptEnabled={true}
+        webviewDebuggingEnabled={__DEV__}
+        onShouldStartLoadWithRequest={({ url }) => {
+          if (isPluginIssueReportUrl(url)) {
+            void Linking.openURL(url);
+            return false;
+          }
+          if (isChapterRefreshUrl(url)) {
+            refetch();
+            return false;
+          }
+          return true;
+        }}
+        onLoadEnd={() => {
+          webViewRef.current?.injectJavaScript(
+            readerSetBatteryLevelGuardedScript(lastKnownBatteryLevel),
           );
           webViewRef.current?.injectJavaScript(
             adjacentChapterScriptRef.current,
@@ -481,24 +479,14 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
           const searchText = searchTextRef.current.trim();
           if (searchText) {
             webViewRef.current?.injectJavaScript(
-              `window.readerSearch?.search(${JSON.stringify(
-                searchText,
-              )}); true;`,
+              readerSearchScript(searchText),
             );
           }
 
           if (autoStartTTSRef.current) {
             autoStartTTSRef.current = false;
             setTimeout(() => {
-              webViewRef.current?.injectJavaScript(`
-              (function() {
-                if (window.tts && reader.generalSettings.val.TTSEnable) {
-                  setTimeout(() => {
-                    tts.start();
-                  }, 500);
-                }
-              })();
-            `);
+              webViewRef.current?.injectJavaScript(ttsAutoStartScript());
             }, 300);
           }
         }}

--- a/src/screens/reader/hooks/useChapter.ts
+++ b/src/screens/reader/hooks/useChapter.ts
@@ -26,6 +26,7 @@ import {
 } from 'react';
 import { sanitizeChapterText } from '../utils/sanitizeChapterText';
 import { parseChapterNumber } from '@utils/parseChapterNumber';
+import { readerSearchNavigateScript, SearchDirection } from '../bridge/search';
 import WebView from 'react-native-webview';
 import { useFullscreenMode } from '@hooks';
 import { Dimensions } from 'react-native';
@@ -373,10 +374,9 @@ export default function useChapter(
   }, [webViewRef]);
 
   const navigateChapterSearch = useCallback(
-    (direction: 'NEXT' | 'PREV', text: string) => {
-      const method = direction === 'NEXT' ? 'next' : 'previous';
+    (direction: SearchDirection, text: string) => {
       webViewRef.current?.injectJavaScript(
-        `window.readerSearch?.${method}(${JSON.stringify(text)}); true;`,
+        readerSearchNavigateScript(direction, text),
       );
     },
     [webViewRef],


### PR DESCRIPTION
## Summary

Extracts the WebView interface between the React Native reader and `assets/reader/js/core.js` / `search.js` into typed TypeScript bridge modules in `src/screens/reader/bridge/`. Scripts emitted through these bridge modules use fixed method-name literals and sanitized numeric arguments, so the method-name interpolation bug class from #2009 is structurally impossible there. The remainder is value-only interpolation (no method names are constructed), out of scope by design, in the reader/settings WebView script surfaces (useChapter.ts, ReaderScreen.tsx, SettingsWebView.tsx); sanitization via sanitizeNumber applies to bridge numeric arguments only.

## What's included (5 commits, `cb1a5d9e..2f34b079`)

- `1dc899e1` typed bridge modules (tts, customJs, reader, search) with contract tests (tts, customJs, reader) and a `coreSurface` parity suite pinning the real `core.js` / `search.js` surfaces (search methods covered there)
- `2d26bc33` search navigation routed through the bridge module (kanban t_afa9836d)
- `316d878d` gitignore tool output (kanban t_ce17a070)
- `d9130022` keep the `:memory:` sentinel intact for op-sqlite on Windows (kanban t_43d6b99c; fix from card t_5396c5d2)
- `2f34b079` pageReader scroll-to-start routed through a typed bridge

## Testing

- rn: 82/82 suites, 413/413 tests green
- db: 8/8 suites, 197/197 tests green (fix landed in d9130022; reproduced by SRAL delta verdict t_4e5dd7ba)
- tsc, eslint, prettier clean

## Exclusions

- The rsvp bridge is intentionally not included: window.rsvp does not exist on upstream master until upstream PR #2009 (RsvpTab) merges; tracked separately (kanban t_38ff5fae, blocked).

Part of the architecture-review track (kanban t_e634f3dd)

Generated with Hermes (builder-bot agent).

Co-authored-by: Hermes builder-bot <builder-bot@hermes.local>
