### PR TITLE
feat: Persist floating TTS controller position across chapters (#2000)

### DIFF
--- a/assets/reader/js/index.js
+++ b/assets/reader/js/index.js
@@ -316,6 +316,10 @@ const TTSController = () => {
   let lastBubbleTouchEnd = 0;
   const savedTtsControllerPosition =
     initialReaderConfig?.ttsControllerPosition ?? null;
+  // Latest position applied or persisted; re-applied after the van style
+  // binding replaces the whole inline style string (TTS toggle).
+  let lastAppliedPosition = savedTtsControllerPosition;
+  let restoringPosition = false;
 
   const stopEvent = e => {
     e.preventDefault();
@@ -358,32 +362,33 @@ const TTSController = () => {
   };
 
   /**
-   * One post per drag gesture, on release. Reads the inline px left/top and
-   * skips the post when they are absent (a tap that never moved is guarded by
-   * the NaN check: parseFloat('') is NaN, so the default CSS position is
-   * never persisted over a real saved one).
+   * One post per drag gesture, on release; only when it actually moved
+   * (wasMoved). A tap must never persist a clamped default position.
    */
-  const postTtsControllerPosition = () => {
+  const postTtsControllerPosition = wasMoved => {
+    if (!wasMoved) {
+      return;
+    }
     const left = parseFloat(controllerElement?.style?.left);
     const top = parseFloat(controllerElement?.style?.top);
     if (Number.isFinite(left) && Number.isFinite(top)) {
+      lastAppliedPosition = { left, top };
       reader.post({ type: 'tts-controller-position', data: { left, top } });
     }
   };
 
   /**
-   * Apply the position saved by a previous chapter (MMKV key
-   * TTS_CONTROLLER_POSITION, bridged through initialReaderConfig). Single rAF:
-   * apply + clamp land together before the first paint, so there is no flash
-   * of the CSS default position.
+   * Apply the saved (or last persisted) controller position. Single rAF:
+   * apply + clamp land before the first paint, so there is no flash of the
+   * CSS default position.
    */
-  const applySavedTtsControllerPosition = () => {
+  const applyControllerPosition = () => {
     controllerElement ??= document.getElementById('TTS-Controller');
-    if (!controllerElement || !savedTtsControllerPosition) {
+    if (!controllerElement || !lastAppliedPosition) {
       return;
     }
-    controllerElement.style.left = `${savedTtsControllerPosition.left}px`;
-    controllerElement.style.top = `${savedTtsControllerPosition.top}px`;
+    controllerElement.style.left = `${lastAppliedPosition.left}px`;
+    controllerElement.style.top = `${lastAppliedPosition.top}px`;
     // Clamp only when the controller is VISIBLE (TTS enabled). A hidden
     // (display:none) element has 0 size and clamp would math to 8,8 and
     // destroy the saved position.
@@ -394,6 +399,27 @@ const TTSController = () => {
       clampControllerToViewport();
     }
   };
+
+  /**
+   * The van style binding replaces the WHOLE inline style string when
+   * TTSEnable changes, wiping left/top set here. Re-apply the last position
+   * on that wipe (clamping when visible; preserving it while hidden).
+   */
+  const positionObserver =
+    typeof MutationObserver === 'undefined'
+      ? null
+      : new MutationObserver(() => {
+          if (restoringPosition) {
+            return;
+          }
+          const left = controllerElement?.style?.left;
+          const top = controllerElement?.style?.top;
+          if (!left && !top && lastAppliedPosition) {
+            restoringPosition = true;
+            applyControllerPosition();
+            restoringPosition = false;
+          }
+        });
 
   const setCollapsed = value => {
     collapsed.val = value;
@@ -455,8 +481,9 @@ const TTSController = () => {
     }
     hoverElement?.classList.remove('highlight');
     hoverElement = null;
+    const wasMoved = moved;
     moved = false;
-    postTtsControllerPosition();
+    postTtsControllerPosition(wasMoved);
   };
 
   const startBubbleDrag = e => {
@@ -504,9 +531,10 @@ const TTSController = () => {
     }
     stopEvent(e);
     const shouldExpand = !moved;
+    const wasMoved = moved;
     lastBubbleTouchEnd = Date.now();
     finishBubbleDrag();
-    postTtsControllerPosition();
+    postTtsControllerPosition(wasMoved);
     if (shouldExpand) {
       setCollapsed(false);
     }
@@ -518,7 +546,10 @@ const TTSController = () => {
     }
     stopEvent(e);
     lastBubbleTouchEnd = Date.now();
+    const wasMoved = moved;
     finishBubbleDrag();
+    // A cancel during a real drag must persist the new position (C4).
+    postTtsControllerPosition(wasMoved);
   };
 
   const toggleCollapsed = e => {
@@ -548,11 +579,20 @@ const TTSController = () => {
     onclick: toggleCollapsed,
   });
 
-  // Apply the saved position before the first paint, and re-clamp on
-  // orientation changes (the WebView re-lays out without reloading, so
-  // window resize is the signal; 'active' is present during a drag, so the
-  // user's in-progress drag is never disturbed).
-  requestAnimationFrame(applySavedTtsControllerPosition);
+  // Apply the saved position before the first paint, re-clamp on orientation
+  // changes (resize is the signal; a drag keeps 'active'), and watch the
+  // style attribute because the van style binding replaces the whole inline
+  // style string on TTSEnable changes.
+  requestAnimationFrame(() => {
+    applyControllerPosition();
+    controllerElement ??= document.getElementById('TTS-Controller');
+    if (controllerElement && positionObserver) {
+      positionObserver.observe(controllerElement, {
+        attributes: true,
+        attributeFilter: ['style'],
+      });
+    }
+  });
   window.addEventListener('resize', () => {
     controllerElement ??= document.getElementById('TTS-Controller');
     if (controllerElement && !controllerElement.classList.contains('active')) {

--- a/assets/reader/js/index.js
+++ b/assets/reader/js/index.js
@@ -314,6 +314,8 @@ const TTSController = () => {
   const collapsed = van.state(true);
   let collapseButtonElement = null;
   let lastBubbleTouchEnd = 0;
+  const savedTtsControllerPosition =
+    initialReaderConfig?.ttsControllerPosition ?? null;
 
   const stopEvent = e => {
     e.preventDefault();
@@ -353,6 +355,44 @@ const TTSController = () => {
     )}px`;
     controllerElement.style.right = 'auto';
     controllerElement.style.bottom = 'auto';
+  };
+
+  /**
+   * One post per drag gesture, on release. Reads the inline px left/top and
+   * skips the post when they are absent (a tap that never moved is guarded by
+   * the NaN check: parseFloat('') is NaN, so the default CSS position is
+   * never persisted over a real saved one).
+   */
+  const postTtsControllerPosition = () => {
+    const left = parseFloat(controllerElement?.style?.left);
+    const top = parseFloat(controllerElement?.style?.top);
+    if (Number.isFinite(left) && Number.isFinite(top)) {
+      reader.post({ type: 'tts-controller-position', data: { left, top } });
+    }
+  };
+
+  /**
+   * Apply the position saved by a previous chapter (MMKV key
+   * TTS_CONTROLLER_POSITION, bridged through initialReaderConfig). Single rAF:
+   * apply + clamp land together before the first paint, so there is no flash
+   * of the CSS default position.
+   */
+  const applySavedTtsControllerPosition = () => {
+    controllerElement ??= document.getElementById('TTS-Controller');
+    if (!controllerElement || !savedTtsControllerPosition) {
+      return;
+    }
+    controllerElement.style.left = `${savedTtsControllerPosition.left}px`;
+    controllerElement.style.top = `${savedTtsControllerPosition.top}px`;
+    // Clamp only when the controller is VISIBLE (TTS enabled). A hidden
+    // (display:none) element has 0 size and clamp would math to 8,8 and
+    // destroy the saved position.
+    if (
+      controllerElement.offsetWidth !== 0 &&
+      controllerElement.offsetHeight !== 0
+    ) {
+      clampControllerToViewport();
+    }
   };
 
   const setCollapsed = value => {
@@ -416,6 +456,7 @@ const TTSController = () => {
     hoverElement?.classList.remove('highlight');
     hoverElement = null;
     moved = false;
+    postTtsControllerPosition();
   };
 
   const startBubbleDrag = e => {
@@ -465,6 +506,7 @@ const TTSController = () => {
     const shouldExpand = !moved;
     lastBubbleTouchEnd = Date.now();
     finishBubbleDrag();
+    postTtsControllerPosition();
     if (shouldExpand) {
       setCollapsed(false);
     }
@@ -504,6 +546,18 @@ const TTSController = () => {
     ontouchend: endBubbleDrag,
     ontouchcancel: cancelBubbleDrag,
     onclick: toggleCollapsed,
+  });
+
+  // Apply the saved position before the first paint, and re-clamp on
+  // orientation changes (the WebView re-lays out without reloading, so
+  // window resize is the signal; 'active' is present during a drag, so the
+  // user's in-progress drag is never disturbed).
+  requestAnimationFrame(applySavedTtsControllerPosition);
+  window.addEventListener('resize', () => {
+    controllerElement ??= document.getElementById('TTS-Controller');
+    if (controllerElement && !controllerElement.classList.contains('active')) {
+      clampControllerToViewport();
+    }
   });
 
   return div(

--- a/src/hooks/persisted/useSettings.ts
+++ b/src/hooks/persisted/useSettings.ts
@@ -39,6 +39,13 @@ export const LIBRARY_SETTINGS = 'LIBRARY_SETTINGS';
 export const CHAPTER_GENERAL_SETTINGS = 'CHAPTER_GENERAL_SETTINGS';
 export const CHAPTER_READER_SETTINGS = 'CHAPTER_READER_SETTINGS';
 
+/**
+ * Floating TTS controller position (#2000). The controller is rendered in the
+ * reader WebView (assets/reader/js/index.js) and its dragged position is
+ * absolute px. null means the user never moved it, so the CSS default applies.
+ */
+export const TTS_CONTROLLER_POSITION = 'TTS_CONTROLLER_POSITION';
+
 export interface AppSettings {
   /**
    * General settings

--- a/src/screens/reader/components/WebViewReader.tsx
+++ b/src/screens/reader/components/WebViewReader.tsx
@@ -22,6 +22,11 @@ import {
   initialChapterGeneralSettings,
   initialChapterReaderSettings,
 } from '@hooks/persisted/useSettings';
+import {
+  getSavedTtsControllerPosition,
+  parseTtsControllerPosition,
+  saveTtsControllerPosition,
+} from './ttsControllerPosition';
 import { getBatteryLevel } from 'react-native-device-info';
 import { PLUGIN_STORAGE } from '@utils/Storages';
 import { useChapterContext } from '../ChapterContext';
@@ -397,6 +402,7 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
                   chapterGeneralSettings,
                   novel,
                   chapter,
+                  ttsControllerPosition: getSavedTtsControllerPosition(),
                   batteryLevel,
                   autoSaveInterval: 2222,
                   DEBUG: __DEV__,
@@ -554,6 +560,13 @@ const WebViewReader: React.FC<WebViewReaderProps> = ({
                     seekTts(data.index);
                   }
                   break;
+              }
+              break;
+            }
+            case 'tts-controller-position': {
+              const pos = parseTtsControllerPosition(event.data);
+              if (pos) {
+                saveTtsControllerPosition(pos);
               }
               break;
             }

--- a/src/screens/reader/components/__tests__/ttsControllerPosition.test.ts
+++ b/src/screens/reader/components/__tests__/ttsControllerPosition.test.ts
@@ -1,0 +1,67 @@
+import { MMKVStorage } from '@utils/mmkv/mmkv';
+import { TTS_CONTROLLER_POSITION } from '@hooks/persisted/useSettings';
+import {
+  getSavedTtsControllerPosition,
+  parseTtsControllerPosition,
+  saveTtsControllerPosition,
+} from '../ttsControllerPosition';
+
+describe('ttsControllerPosition', () => {
+  beforeEach(() => {
+    MMKVStorage.clearAll();
+  });
+
+  describe('TTS_CONTROLLER_POSITION', () => {
+    it('is the MMKV key for the floating TTS controller position (#2000)', () => {
+      expect(TTS_CONTROLLER_POSITION).toBe('TTS_CONTROLLER_POSITION');
+    });
+  });
+
+  describe('parseTtsControllerPosition', () => {
+    it('accepts a valid { left, top } payload', () => {
+      expect(parseTtsControllerPosition({ left: 100, top: 200 })).toEqual({
+        left: 100,
+        top: 200,
+      });
+    });
+
+    it('allows unknown extra keys', () => {
+      expect(
+        parseTtsControllerPosition({ left: 10, top: 20, extra: 'ignored' }),
+      ).toEqual({ left: 10, top: 20 });
+    });
+
+    it.each([
+      ['null', null],
+      ['a string', 'x'],
+      ['an empty object', {}],
+      ['string left', { left: '1', top: 10 }],
+      ['NaN left', { left: NaN, top: 10 }],
+      ['missing left', { top: 1 }],
+      ['undefined top', { left: 1, top: undefined }],
+    ])('rejects %s', (_name, data) => {
+      expect(parseTtsControllerPosition(data)).toBeNull();
+    });
+  });
+
+  describe('save/get round trip', () => {
+    it('persists { left, top } under TTS_CONTROLLER_POSITION', () => {
+      saveTtsControllerPosition({ left: 120, top: 640 });
+
+      expect(MMKVStorage.contains(TTS_CONTROLLER_POSITION)).toBe(true);
+      expect(getSavedTtsControllerPosition()).toEqual({ left: 120, top: 640 });
+    });
+
+    it('returns null (not undefined) when the key is absent', () => {
+      expect(getSavedTtsControllerPosition()).toBeNull();
+    });
+
+    it('returns null instead of throwing on corrupt stored data', () => {
+      // getMMKVObject JSON.parse throws on malformed values; a cosmetic
+      // position read must never break the reader's per-chapter build.
+      MMKVStorage.set(TTS_CONTROLLER_POSITION, '{not-json');
+
+      expect(getSavedTtsControllerPosition()).toBeNull();
+    });
+  });
+});

--- a/src/screens/reader/components/__tests__/ttsControllerPosition.test.ts
+++ b/src/screens/reader/components/__tests__/ttsControllerPosition.test.ts
@@ -11,12 +11,6 @@ describe('ttsControllerPosition', () => {
     MMKVStorage.clearAll();
   });
 
-  describe('TTS_CONTROLLER_POSITION', () => {
-    it('is the MMKV key for the floating TTS controller position (#2000)', () => {
-      expect(TTS_CONTROLLER_POSITION).toBe('TTS_CONTROLLER_POSITION');
-    });
-  });
-
   describe('parseTtsControllerPosition', () => {
     it('accepts a valid { left, top } payload', () => {
       expect(parseTtsControllerPosition({ left: 100, top: 200 })).toEqual({

--- a/src/screens/reader/components/ttsControllerPosition.ts
+++ b/src/screens/reader/components/ttsControllerPosition.ts
@@ -1,0 +1,58 @@
+import { getMMKVObject, setMMKVObject } from '@utils/mmkv/mmkv';
+import { TTS_CONTROLLER_POSITION } from '@hooks/persisted/useSettings';
+
+/**
+ * Saved floating TTS controller position (#2000). Absolute px as produced by
+ * assets/reader/js/index.js, already clamped to the viewport.
+ */
+export type TtsControllerPosition = { left: number; top: number };
+
+/**
+ * Shape validation for the tts-controller-position message payload. Accepts
+ * only an object whose left and top are finite numbers; anything else -> null.
+ * The JS side already clamps to >=8px, so this is shape validation only.
+ */
+export const parseTtsControllerPosition = (
+  data: unknown,
+): TtsControllerPosition | null => {
+  if (typeof data !== 'object' || data === null) {
+    return null;
+  }
+  const { left, top } = data as { left?: unknown; top?: unknown };
+  if (
+    typeof left !== 'number' ||
+    !Number.isFinite(left) ||
+    typeof top !== 'number' ||
+    !Number.isFinite(top)
+  ) {
+    return null;
+  }
+  return { left, top };
+};
+
+/**
+ * Read the saved position; null when absent (never undefined). The try/catch
+ * guards against corrupt stored data: getMMKVObject JSON.parse throws on a
+ * malformed value, and a cosmetic position read must never break the reader's
+ * per-chapter build.
+ */
+export const getSavedTtsControllerPosition =
+  (): TtsControllerPosition | null => {
+    try {
+      return (
+        getMMKVObject<TtsControllerPosition>(TTS_CONTROLLER_POSITION) ?? null
+      );
+    } catch {
+      return null;
+    }
+  };
+
+/**
+ * Persist a controller position. Called from the WebView onMessage handler on
+ * drag release; one call per gesture.
+ */
+export const saveTtsControllerPosition = (
+  position: TtsControllerPosition,
+): void => {
+  setMMKVObject(TTS_CONTROLLER_POSITION, position);
+};


### PR DESCRIPTION
## Summary

The floating TTS controller is the small draggable panel shown during text to speech. Its position (left, top) was not saved. The controller reset to the default corner when the reader opened the next chapter.

This change saves the position in the on-device key-value store (MMKV) and restores it for the next chapter.

## What is included (2 commits)

- Save the position when the user releases a drag.
- Save only when the user really moves the controller.
- Restore the saved position when text to speech starts after a chapter is open.
- Save the position when a move ends by touch cancel.
- Check the position payload shape before saving.
- Remove a test that checked a constant against itself.

## Testing

- Automated suite: 78/78 suites, 381/381 tests green.
- Manual on-device check: still to be done before merge.

## Note

The WebView message type registration comes from open pull request #2014.

Closes #2000

AI-assisted: generated with Hermes (builder-bot agent)

Co-authored-by: Hermes builder-bot <builder-bot@hermes.local>