### PR TITLE
fix: Prevent Crash in `parseChapterNumber` When Chapter or Novel Name Is Missing

### DIFF
--- a/src/utils/__tests__/parseChapterNumber.test.ts
+++ b/src/utils/__tests__/parseChapterNumber.test.ts
@@ -1,0 +1,33 @@
+import { parseChapterNumber } from '../parseChapterNumber';
+
+describe('parseChapterNumber', () => {
+  it('returns the provided chapterNumber when valid', () => {
+    expect(parseChapterNumber('Novel', 'Chapter 5', 5)).toBe(5);
+  });
+
+  it('parses a basic chapter number from the name', () => {
+    expect(parseChapterNumber('Novel', 'Chapter 12')).toBe(12);
+  });
+
+  it('does not throw when chapterName is undefined', () => {
+    expect(parseChapterNumber('Novel', undefined as unknown as string)).toBe(
+      -1,
+    );
+  });
+
+  it('does not throw when chapterName is null', () => {
+    expect(parseChapterNumber('Novel', null as unknown as string)).toBe(-1);
+  });
+
+  it('falls back to the given chapterNumber when chapterName is missing', () => {
+    expect(
+      parseChapterNumber('Novel', undefined as unknown as string, -1),
+    ).toBe(-1);
+  });
+
+  it('does not throw when novelName is undefined', () => {
+    expect(
+      parseChapterNumber(undefined as unknown as string, 'Chapter 3'),
+    ).toBe(3);
+  });
+});

--- a/src/utils/parseChapterNumber.ts
+++ b/src/utils/parseChapterNumber.ts
@@ -9,6 +9,10 @@ export const parseChapterNumber = (
     return chapterNumber;
   }
 
+  if (!chapterName) {
+    return chapterNumber ?? -1;
+  }
+
   const basic = new RegExp(/(?<=ch[^\d]*[\s]*)([0-9]+)(\.[0-9]+)?(\.?[a-z]+)?/);
   const number = new RegExp(/([0-9]+)(\.[0-9]+)?(\.?[a-z]+)?/);
   const unwantedWhiteSpace = new RegExp(/\s(?=extra|special|omake)/g);
@@ -16,7 +20,7 @@ export const parseChapterNumber = (
     /\b(?:v|ver|vol|version|volume|season|s)[^a-z]?[0-9]+/g,
   );
   let name = chapterName.toLowerCase();
-  name = name.replace(novelName.toLowerCase(), '').trim();
+  name = name.replace((novelName ?? '').toLowerCase(), '').trim();
   name = name.replace(',', '.').replace('-', '.');
   name = name.replace(unwantedWhiteSpace, '');
   name = name.replace(unwanted, '');


### PR DESCRIPTION
## Summary
- Users reported the Updates screen crashing with `TypeError: Cannot read property 'toLowerCase' of undefined` inside `parseChapterNumber`, called from `useDetailedUpdates`.
- `parseChapterNumber` called `chapterName.toLowerCase()` unconditionally. Although `Update.name` is typed as a non-null `string`, it comes straight from the SQLite `Chapter.name` column with no runtime guarantee, so a chapter with a missing name crashed the whole screen.
- Added a guard that returns the fallback `chapterNumber` (or `-1`) when `chapterName` is missing, and defensively coerced `novelName` too since it's used the same way.

## Test plan
- [x] Added `src/utils/__tests__/parseChapterNumber.test.ts` covering undefined/null `chapterName`/`novelName` plus existing happy-path parsing.
- [x] `npx jest src/utils/__tests__ src/screens/reader/hooks/__tests__/useChapter.test.ts` passes.
- [x] `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WW3AHpNPxoRVsbAMVRX6T

---
_Generated by [Claude Code](https://claude.ai/code/session_011WW3AHpNPxoRVsbAMVRX6T)_